### PR TITLE
feat(bug-fixing): add --cpuset and --memory CLI arguments for resource control

### DIFF
--- a/bug_fixing/src/__main__.py
+++ b/bug_fixing/src/__main__.py
@@ -104,6 +104,8 @@ def main():  # pylint: disable=too-many-branches,too-many-return-statements
             _get_path_or_none(args.hints),
             Path(args.out),
             log_dir=log_dir,
+            cpuset=args.cpuset,
+            memory=args.memory,
         )
         # FIXME: Bandaid solution for permission issues when runner executes as root
         change_ownership_with_docker(Path(args.out))
@@ -266,6 +268,16 @@ def _get_parser():  # pylint: disable=too-many-statements,too-many-locals
         "--log-dir",
         default=None,
         help="Directory to save CRS execution logs. Default: {out}/logs/",
+    )
+    run_crs_parser.add_argument(
+        "--cpuset",
+        default=None,
+        help="CPU cores to pin the CRS container to (e.g., '0-3' or '0,2,4,6'). Maps to docker --cpuset-cpus.",
+    )
+    run_crs_parser.add_argument(
+        "--memory",
+        default=None,
+        help="Memory limit for the CRS container (e.g., '4G' or '512M'). Maps to docker --memory.",
     )
 
     run_pov_parser = subparsers.add_parser(

--- a/bug_fixing/src/oss_patch/crs_runner/__init__.py
+++ b/bug_fixing/src/oss_patch/crs_runner/__init__.py
@@ -106,6 +106,8 @@ class OSSPatchCRSRunner:
         work_dir: Path,
         out_dir: Path | None = None,
         log_dir: Path | None = None,
+        cpuset: str | None = None,
+        memory: str | None = None,
     ):
         self.project_name = project_name
         self.work_dir = work_dir
@@ -115,6 +117,8 @@ class OSSPatchCRSRunner:
 
         self.out_dir = out_dir
         self.log_dir = log_dir
+        self.cpuset = cpuset
+        self.memory = memory
 
         if out_dir and not out_dir.exists():
             out_dir.mkdir()
@@ -372,8 +376,15 @@ class OSSPatchCRSRunner:
                 tmp_oss_fuzz_path = crs_run_tmp_dir / "oss-fuzz"
                 tmp_proj_src_path = crs_run_tmp_dir / "proj-src"
 
+                resource_flags = ""
+                if self.cpuset:
+                    resource_flags += f"--cpuset-cpus={self.cpuset} "
+                if self.memory:
+                    resource_flags += f"--memory={self.memory} "
+
                 command = (
                     f"docker run --rm --privileged "
+                    f"{resource_flags}"
                     f"-v {OSS_PATCH_DOCKER_IMAGES_FOR_CRS_VOLUME}:/var/lib/docker "
                     f"-v {tmp_oss_fuzz_path}:/oss-fuzz "
                     f"-v {tmp_proj_src_path}:/cp-sources "

--- a/bug_fixing/src/oss_patch/oss_patch.py
+++ b/bug_fixing/src/oss_patch/oss_patch.py
@@ -210,6 +210,8 @@ class OSSPatch:
         hints_dir: Path | None,
         out_dir: Path,
         log_dir: Path | None = None,
+        cpuset: str | None = None,
+        memory: str | None = None,
     ) -> bool:
         assert self.crs_name
 
@@ -217,7 +219,12 @@ class OSSPatch:
         effective_log_dir = log_dir if log_dir else out_dir / "logs"
 
         oss_patch_runner = OSSPatchCRSRunner(
-            self.project_name, self.project_work_dir, out_dir, log_dir=effective_log_dir
+            self.project_name,
+            self.project_work_dir,
+            out_dir,
+            log_dir=effective_log_dir,
+            cpuset=cpuset,
+            memory=memory,
         )
 
         return oss_patch_runner.run_crs_against_povs(


### PR DESCRIPTION
## Summary

Add `--cpuset` and `--memory` CLI arguments to oss-patch (bug-fixing CRS) to enable CPU pinning and memory limits for CRS containers.

## Description

The bug-finding CRS supports resource constraints via `config-resource.yaml`, but bug-fixing CRS (oss-patch) has no way to configure CPU and memory limits. This adds CLI arguments to specify these constraints directly when running the CRS.

## Problem

bug-fixing CRS runs `docker run` without any resource flags:

```python
# bug_fixing/src/oss_patch/crs_runner/__init__.py
command = (
    f"docker run --rm --privileged "
    f"-v {OSS_PATCH_DOCKER_IMAGES_FOR_CRS_VOLUME}:/var/lib/docker "
    ...
)
# No --cpuset-cpus or --memory flags
```

## Current Status

| Component | Resource Config |
|-----------|----------------|
| bug-finding | config-resource.yaml (cpuset, memory) |
| bug-fixing | None |

## Proposed Solution

Add CLI arguments that map to Docker flags:
- `--cpuset "0-3"` → `docker run --cpuset-cpus=0-3`
- `--memory "4G"` → `docker run --memory=4G`

Closes #21