### PR TITLE
fix: checkout oss-fuzz per project in separate dir

### DIFF
--- a/bug_finding/src/__main__.py
+++ b/bug_finding/src/__main__.py
@@ -167,8 +167,8 @@ def main():
         logging.info(f"Creating build directory: {build_dir}")
         build_dir.mkdir(parents=True, exist_ok=True)
 
-    # Always use standard oss-fuzz directory location
-    oss_fuzz_dir = (build_dir / "crs" / "oss-fuzz").resolve()
+    # Always use standard oss-fuzz directory location (per-project isolation)
+    oss_fuzz_dir = (build_dir / "crs" / "oss-fuzz" / args.project).resolve()
 
     # Resolve source oss-fuzz directory if provided (for copying)
     source_oss_fuzz_dir = args.oss_fuzz_dir.resolve() if args.oss_fuzz_dir else None

--- a/crs_registry/atlantis-c-libafl/pkg.yaml
+++ b/crs_registry/atlantis-c-libafl/pkg.yaml
@@ -1,5 +1,4 @@
 name: atlantis-c-libafl
 type: bug-finding
 source:
-  url: https://github.com/Team-Atlanta/atlantis-c-libafl-snapshot
-  ref: main
+  local_path: ~/post/atlantis-c-libafl-snapshot

--- a/crs_registry/crs-libfuzzer/pkg.yaml
+++ b/crs_registry/crs-libfuzzer/pkg.yaml
@@ -1,5 +1,4 @@
 name: crs-libfuzzer
 type: bug-finding
 source:
-  url: https://github.com/Team-Atlanta/crs-libfuzzer
-  ref: main
+  local_path: ~/post/crs-libfuzzer

--- a/crs_registry/mock-dind/pkg.yaml
+++ b/crs_registry/mock-dind/pkg.yaml
@@ -1,5 +1,4 @@
 name: mock-dind
 type: bug-finding
 source:
-  url: https://github.com/Team-Atlanta/crs-libfuzzer
-  ref: dind
+  local_path: ~/post/mock-dind

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,8 @@ include = [
     "bug_finding",
     "bug_fixing",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (require network access, may be slow)",
+]


### PR DESCRIPTION
Issue was the conditional cloning/rsync did not overwrite build/crs/oss-fuzz dir for different projects. 
Since rsync only copies a single project/<subdir>, running oss-crs on a different project could not find the appropriate files.

Added sparse checkout to shallow clone to mimic rsync behaviour.

Fix is to **checkout oss-fuzz on a per-project basis**. The directory is space optimized now that this is acceptable (<60MB).

Creating PR to track the directory structure change.