### PR TITLE
feat(bug-finding): delimit run data with run-id

### DIFF
--- a/bug_finding/src/render_compose/render.py
+++ b/bug_finding/src/render_compose/render.py
@@ -287,6 +287,7 @@ def render_compose_for_worker(
     ensemble_dir: Path | None = None,
     harness_name: str | None = None,
     coverage_build_dir: str | None = None,
+    run_id: str | None = None,
     # LiteLLM-related parameters (for run mode with internal LiteLLM)
     postgres_password: str | None = None,
     litellm_master_key: str | None = None,
@@ -355,6 +356,7 @@ def render_compose_for_worker(
         external_litellm=external_litellm,
         ensemble_dir=str(ensemble_dir) if ensemble_dir else None,
         coverage_build_dir=coverage_build_dir,
+        run_id=run_id,
         # LiteLLM-related variables (for run mode with internal LiteLLM)
         postgres_password=postgres_password,
         litellm_master_key=litellm_master_key,
@@ -556,6 +558,7 @@ def render_run_compose(
         ensemble_dir=ensemble_dir,
         harness_name=harness_name,
         coverage_build_dir=str(coverage_build_dir) if coverage_build_dir else None,
+        run_id=actual_run_id,
         postgres_password=postgres_password,
         litellm_master_key=litellm_master_key,
         litellm_keys=litellm_keys,

--- a/bug_finding/templates/compose.yaml.j2
+++ b/bug_finding/templates/compose.yaml.j2
@@ -188,9 +188,9 @@ services:
       - HOST_ARTIFACT_DIR={{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}
 {%- if harness_name %}
       # Per-harness HOST paths for nested containers (host_docker_builder mode)
-      - HOST_POV_DIR={{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/povs
-      - HOST_CORPUS_DIR={{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/corpus
-      - HOST_CRS_DATA_DIR={{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/crs-data
+      - HOST_POV_DIR={{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/povs
+      - HOST_CORPUS_DIR={{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/corpus
+      - HOST_CRS_DATA_DIR={{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/crs-data
 {%- endif %}
 {%- endif %}
     build:
@@ -203,10 +203,10 @@ services:
 {%- endif %}
       - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}:/artifacts
 {%- if harness_name %}
-      # Per-harness artifact overlays (povs, corpus, crs-data are per-harness)
-      - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/povs:/artifacts/povs
-      - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/corpus:/artifacts/corpus
-      - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/crs-data:/artifacts/crs-data
+      # Per-run writable overlays (povs, corpus, crs-data isolated per run)
+      - {{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/povs:/artifacts/povs
+      - {{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/corpus:/artifacts/corpus
+      - {{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/crs-data:/artifacts/crs-data
 {%- endif %}
 {%- if crs.host_docker_builder %}
       - /var/run/docker.sock:/var/run/docker.sock
@@ -249,11 +249,11 @@ services:
       - {{ ensemble_dir }}/povs:/ensemble/povs:rw
       # Mount each CRS corpus directory as read-only
 {%- for crs in crs_list %}
-      - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/corpus:/watch/corpus/{{ crs.name }}:ro
+      - {{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/corpus:/watch/corpus/{{ crs.name }}:ro
 {%- endfor %}
       # Mount each CRS povs directory as read-only
 {%- for crs in crs_list %}
-      - {{ build_dir }}/artifacts/{{ crs.name }}/{{ project }}/run/{{ harness_name }}/povs:/watch/povs/{{ crs.name }}:ro
+      - {{ build_dir }}/run/{{ crs.name }}/{{ project }}/{{ harness_name }}/{{ run_id }}/povs:/watch/povs/{{ crs.name }}:ro
 {%- endfor %}
     command:
       - python3


### PR DESCRIPTION
Closes #33 

Running the following
```
uv run oss-bugfind-crs run --run-id 100 --external-litellm example_configs/crs-libfuzzer aixcc/c/sanity-mock-c-delta-01 fuzz_process_input_header
uv run oss-bugfind-crs run --external-litellm example_configs/crs-libfuzzer aixcc/c/sanity-mock-c-delta-01 fuzz_process_input_header
```

Yields this dir structure

```
$ tree -L 7 run
build/run
└── crs-libfuzzer
    └── aixcc
        └── c
            └── sanity-mock-c-delta-01
                └── fuzz_process_input_header
                    ├── 100
                    │   ├── corpus
                    │   ├── crs-data
                    │   └── povs
                    └── 12b18b5fc9920fa6
                        ├── corpus
                        ├── crs-data
                        └── povs
```