### PR TITLE
fix(oss-patch): preserve timestamps and permissions in docker copy

### DIFF
--- a/bug_fixing/src/oss_patch/functions.py
+++ b/bug_fixing/src/oss_patch/functions.py
@@ -358,7 +358,7 @@ def copy_directory_with_docker(src_path: Path, dst_path: Path) -> bool:
         f"-v {src_path.resolve().parent}:/src "
         f"-v {dst_path.resolve().parent}:/dst "
         f"alpine:latest "
-        f"cp -r /src/{src_path.name} /dst/{dst_path.name}"
+        f"cp -a /src/{src_path.name} /dst/{dst_path.name}"
     )
 
     proc = subprocess.run(


### PR DESCRIPTION
## Summary
- Fix docker copy to preserve file timestamps and permissions

## Description
Changes `cp -r` to `cp -a` (archive mode) in `copy_directory_with_docker()`.

### Problem
When taking inc-build snapshots, the timestamp of source code changes because `cp -r` doesn't preserve timestamps. This causes build systems to detect all files as modified and trigger a full rebuild instead of incremental build.

### Solution
Use `cp -a` (archive mode) which preserves:
- Timestamps (modification time, access time)
- File permissions
- Ownership attributes

### Example
- afc-wireshark-*