### PR TITLE
fix: pass BUILDKIT_SYNTAX arg for COPY --exclude support

### DIFF
--- a/oss_crs/src/target.py
+++ b/oss_crs/src/target.py
@@ -335,6 +335,8 @@ class Target:
                 "docker",
                 "buildx",
                 "build",
+                "--build-arg",
+                "BUILDKIT_SYNTAX=docker/dockerfile:1",
                 "--build-context",
                 f"repo_path={self.repo_path}",
                 "-t",


### PR DESCRIPTION
## Summary
- Pass `--build-arg BUILDKIT_SYNTAX=docker/dockerfile:1` to `docker buildx build` in the repo-injection build path
- This avoids modifying the Dockerfile content, which could conflict with existing `# syntax=` directives

## Problem
Any target built with `--target-source-path` fails with:
```
dockerfile parse error on line X: unknown flag: --exclude
```
This is because `__build_docker_image_with_repo` appends `COPY --exclude=.git/FETCH_HEAD ...` to the generated Dockerfile, but Docker's built-in Dockerfile parser does not support the `--exclude` flag — regardless of Docker version (tested on Docker 28.4.0). The extended BuildKit frontend (`docker/dockerfile:1`) is required.

Standard oss-fuzz projects built without `--target-source-path` are unaffected because they go through the plain build path which does not use `COPY --exclude`.

## Test plan
- [x] Verified `COPY --exclude` fails without fix on Docker 28.4.0
- [x] Verified build succeeds with `BUILDKIT_SYNTAX` build arg
- [x] Tested with AIxCC target (`sanity-mock-c-delta-01`) using `--target-source-path`
- [x] Plain build path (no repo) unaffected