### PR TITLE
feat: auto-clone target repo from main_repo in project.yaml

### DIFF
--- a/oss_crs/src/target.py
+++ b/oss_crs/src/target.py
@@ -90,14 +90,16 @@ class Target:
         self.work_dir = work_dir / "targets" / self.name
         self.work_dir.mkdir(parents=True, exist_ok=True)
 
-        self._user_provided_repo = repo_path is not None
-        if repo_path:
+        self._user_provided_repo = repo_path is not None and str(repo_path) != ""
+        if self._user_provided_repo:
             self.repo_path = repo_path
-        else:
+        elif self.config.main_repo:
             # Default repo path includes hash of repo URL to isolate parallel builds
             # of different repo sources (e.g., different forks or refs)
             repo_key = self._compute_repo_key()
             self.repo_path = work_dir / "targets" / f"{self.name}_{repo_key}" / "repo"
+        else:
+            self.repo_path = None
 
         self.repo_hash: Optional[str] = None
         self.target_harness = target_harness
@@ -105,12 +107,15 @@ class Target:
 
     @property
     def _has_repo(self) -> bool:
-        """Whether a repo path was explicitly provided via --target-source-path."""
-        return self._user_provided_repo
+        """Whether a repo is available — either explicitly provided via
+        --target-source-path or auto-resolved from main_repo in project.yaml."""
+        return self._user_provided_repo or bool(self.config.main_repo)
 
     def _compute_repo_key(self) -> str:
         """Compute a short hash key from repo URL (and ref if specified)."""
         # TODO: Include ref when we add ref support to TargetConfig
+        if not self.config.main_repo:
+            raise ValueError("Cannot compute repo key without main_repo in project.yaml")
         key_source = self.config.main_repo
         return hashlib.sha256(key_source.encode()).hexdigest()[:12]
 


### PR DESCRIPTION
## Summary
- When `--target-source-path` is not provided, automatically clone the repository specified by `main_repo` in `project.yaml`
- Added guard in `_compute_repo_key` for missing `main_repo`
- Fixed `Path("")` edge case in `_user_provided_repo` detection

## Problem
AIxCC targets (under `oss-fuzz/projects/aixcc/`) have `git clone` commented out in their Dockerfiles — they define `main_repo` in `project.yaml` and expect the source to be injected externally. Without `--target-source-path`, these targets fail during `docker build` with errors like:
```
/src/mock-c/mock.c: No such file or directory
```
(`sanity-mock-c-delta-01` as an example.)

Standard oss-fuzz projects are unaffected because their Dockerfiles contain `RUN git clone ...`, so the source is already present in the image regardless of whether `--target-source-path` is provided.

## Behavior after this change
1. User provides `--target-source-path` → use as-is (unchanged)
2. `project.yaml` has `main_repo`, no `--target-source-path` → auto-clone and inject
3. Neither → plain build without repo overlay (unchanged)

## Test plan
- [x] AIxCC target with `main_repo` (`sanity-mock-c-delta-01`): auto-clone + build succeeds
- [x] AIxCC target with explicit `--target-source-path`: uses provided path as-is
- [x] Standard oss-fuzz with `main_repo` (`libxml2`): auto-clone + build succeeds
- [x] Standard oss-fuzz without `main_repo` (`bzip2`): plain build succeeds