### PR TITLE
fix: default to libfuzzer in project.yaml if provided

### DIFF
--- a/oss_crs/src/target.py
+++ b/oss_crs/src/target.py
@@ -10,7 +10,7 @@ import git
 import fcntl
 from contextlib import contextmanager
 
-from .config.target import TargetConfig, TargetSanitizer
+from .config.target import FuzzingEngine, TargetConfig, TargetSanitizer
 from .ui import MultiTaskProgress, TaskResult
 from .utils import generate_random_name, rm_with_docker, log_warning
 from . import ui
@@ -130,7 +130,11 @@ class Target:
         self.main_repo = cfg.main_repo
         self.language = cfg.language.value
         if cfg.fuzzing_engines:
-            self.engine = cfg.fuzzing_engines[0].value
+            # Prefer "libfuzzer" if listed; otherwise use first entry
+            if FuzzingEngine.LIBFUZZER in cfg.fuzzing_engines:
+                self.engine = FuzzingEngine.LIBFUZZER.value
+            else:
+                self.engine = cfg.fuzzing_engines[0].value
         if cfg.sanitizers:
             # Prefer "address" if listed; otherwise use first entry
             if TargetSanitizer.ASAN in cfg.sanitizers:

--- a/oss_crs/tests/unit/test_target_defaults.py
+++ b/oss_crs/tests/unit/test_target_defaults.py
@@ -37,7 +37,8 @@ def test_target_env_uses_project_yaml_when_available(tmp_path: Path) -> None:
     # When "address" is NOT in the list, use first entry
     assert env["sanitizer"] == "memory"
     assert env["architecture"] == "i386"
-    assert env["engine"] == "afl"
+    # When "libfuzzer" IS in the list, prefer it over first entry
+    assert env["engine"] == "libfuzzer"
 
 
 def test_target_env_prefers_address_sanitizer_when_listed(tmp_path: Path) -> None:
@@ -57,6 +58,25 @@ def test_target_env_prefers_address_sanitizer_when_listed(tmp_path: Path) -> Non
     env = target.get_target_env()
     # "address" is preferred even though "memory" is first
     assert env["sanitizer"] == "address"
+
+
+def test_target_env_prefers_libfuzzer_engine_when_listed(tmp_path: Path) -> None:
+    """When 'libfuzzer' is in the fuzzing_engines list, prefer it over first entry."""
+    proj = tmp_path / "proj"
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "project.yaml").write_text(
+        "\n".join(
+            [
+                "language: c",
+                "fuzzing_engines: [afl, honggfuzz, libfuzzer]",
+            ]
+        )
+        + "\n"
+    )
+    target = Target(tmp_path / "work", proj, None)
+    env = target.get_target_env()
+    # "libfuzzer" is preferred even though "afl" is first
+    assert env["engine"] == "libfuzzer"
 
 
 def test_target_env_falls_back_when_project_yaml_invalid(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Default to libfuzzer if it exists in project.yaml

## User Impact

- [x] Internal-only change

## Release Note / Changelog

- [x] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes

## Validation

List tests/checks run and their results.

## Checklist

- [x] I followed Conventional Commits
- [x] I updated docs for behavior/config/CLI changes
- [x] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
