### PR TITLE
fix: always set exchange_dir for user-provided seeds, povs, and diffs

### DIFF
--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -214,12 +214,9 @@ def render_run_crs_compose_docker_compose(
     )
     bug_finding_ensemble = bug_finding_crs_count > 1
     bug_fix_ensemble = any(crs.config.is_bug_fixing_ensemble for crs in crs_compose.crs_list)
-    needs_exchange = bug_finding_ensemble or bug_fix_ensemble
-    exchange_dir = (
-        str(crs_compose.work_dir.get_exchange_dir(target, run_id, sanitizer))
-        if needs_exchange
-        else ""
-    )
+    # Always set exchange_dir — it's the delivery path for POVs, seeds, diffs,
+    # and bug-candidates to all CRS containers via FETCH_DIR mount.
+    exchange_dir = str(crs_compose.work_dir.get_exchange_dir(target, run_id, sanitizer))
 
     target_env = target.get_target_env()
     context = {


### PR DESCRIPTION
## Summary
Always set `exchange_dir` regardless of ensemble mode, since all CRS containers need
the FETCH_DIR mount to receive user-provided seeds, POVs, diffs, and bug-candidates.

## Description
Previously, `exchange_dir` was only set when running in ensemble mode
(`bug_finding_ensemble` or `bug_fix_ensemble`). This meant that in single-CRS runs,
the exchange directory path was empty, preventing users from providing seeds, POVs,
diffs, and bug-candidates via the FETCH_DIR mount.

This was discovered while running a bug-fixing CRS on CRSBench — ground truth POVs
were not being delivered to the container. Additionally, for corpus bootstrapping in
bug-finding CRS scenarios, the fetch directory must also be available by default.

Since always providing the exchange directory has no significant side effects, this
fix removes the conditional and always computes the exchange directory path.