### PR TITLE
fix(run): always start exchange sidecar for SUBMIT_DIR output collection

### DIFF
--- a/oss-crs-infra/exchange/main.py
+++ b/oss-crs-infra/exchange/main.py
@@ -2,7 +2,7 @@
 
 Layout expected:
   /submit/<crs_name>/<data_type_dir>/<hash_file>
-  /exchange/<data_type_dir>/<hash_file>
+  /OSS_CRS_EXCHANGE_DIR/<data_type_dir>/<hash_file>
 
 Directory names are plural (povs, seeds, bug-candidates, patches, diffs).
 Files are already hash-named, so dedup is by filename.
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 
 SUBMIT_ROOT = Path("/submit")
-EXCHANGE_ROOT = Path("/exchange")
+EXCHANGE_ROOT = Path("/OSS_CRS_EXCHANGE_DIR")
 POLL_INTERVAL = 2  # seconds
 
 ALLOWED_DATA_TYPES = {"povs", "seeds", "bug-candidates", "patches", "diffs"}
@@ -40,7 +40,7 @@ def _is_safe_name(name: str) -> bool:
 
 
 def sync_once(created_dirs: set[str], warned_types: set[str]) -> None:
-    """Scan every /submit/<crs>/<type>/ dir and copy unseen files to /exchange/<type>/."""
+    """Scan every /submit/<crs>/<type>/ dir and copy unseen files to /OSS_CRS_EXCHANGE_DIR/<type>/."""
     if not SUBMIT_ROOT.is_dir():
         return
 

--- a/oss-crs-infra/lifecycle/main.py
+++ b/oss-crs-infra/lifecycle/main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import docker
 
-EXCHANGE_ROOT = Path("/exchange")
+EXCHANGE_ROOT = Path("/OSS_CRS_EXCHANGE_DIR")
 
 logging.basicConfig(
     level=logging.INFO,

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -217,9 +217,8 @@ def render_run_crs_compose_docker_compose(
     bug_fix_ensemble = any(
         crs.config.is_bug_fixing_ensemble for crs in crs_compose.crs_list
     )
-    needs_exchange = bug_finding_ensemble or bug_fix_ensemble
     fetch_dir = str(crs_compose.work_dir.get_exchange_dir(target, run_id, sanitizer))
-    exchange_dir = fetch_dir if needs_exchange else ""
+    exchange_dir = fetch_dir
 
     target_env = target.get_target_env()
     context = {

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -158,7 +158,7 @@ services:
     attach: false
     restart: on-failure:3
     volumes:
-      - {{ exchange_dir }}:/exchange:rw
+      - {{ exchange_dir }}:/OSS_CRS_EXCHANGE_DIR:rw
 {%- for crs in crs_list %}
 {%- if not crs.config.is_builder and not crs.config.is_bug_fixing_ensemble %}
       - {{ work_dir.get_submit_dir(crs.name, target, run_id, sanitizer) }}:/submit/{{ crs.name }}:ro
@@ -188,7 +188,7 @@ services:
     attach: false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - {{ exchange_dir }}:/exchange:rw
+      - {{ exchange_dir }}:/OSS_CRS_EXCHANGE_DIR:rw
     environment:
       - COMPOSE_PROJECT={{ crs_compose_name }}
       - WATCH_SERVICES={{ watch_services | join(",") }}

--- a/oss_crs/tests/unit/test_renderer_run_compose.py
+++ b/oss_crs/tests/unit/test_renderer_run_compose.py
@@ -6,7 +6,7 @@ import yaml
 from oss_crs.src.templates.renderer import render_run_crs_compose_docker_compose
 
 
-def test_single_bug_fixing_run_keeps_fetch_mount_without_exchange_sidecar(
+def test_single_bug_fixing_run_keeps_fetch_mount_and_exchange_sidecar(
     monkeypatch, tmp_path: Path
 ) -> None:
     include_fetch_dir_calls: list[bool] = []
@@ -90,4 +90,6 @@ def test_single_bug_fixing_run_keeps_fetch_mount_without_exchange_sidecar(
     assert (
         f"{tmp_path / 'exchange'}:/OSS_CRS_FETCH_DIR:ro" in patcher_service["volumes"]
     )
-    assert "oss-crs-exchange" not in compose_data["services"]
+    # Exchange sidecar is always started — it copies SUBMIT_DIR patches to
+    # EXCHANGE_DIR even for single (non-ensemble) bug-fixing runs.
+    assert "oss-crs-exchange" in compose_data["services"]


### PR DESCRIPTION
## Summary
- Always start the exchange sidecar so single-CRS bug-fixing runs (e.g., `crs-claude-code`) have their `SUBMIT_DIR` patches copied to `EXCHANGE_DIR` for CRSBench collection
- Rename `/exchange` mount to `/OSS_CRS_EXCHANGE_DIR` for naming consistency with other mount points (`OSS_CRS_SUBMIT_DIR`, `OSS_CRS_FETCH_DIR`, etc.)

## Problem
The exchange sidecar was gated on `needs_exchange` (`bug_finding_ensemble or bug_fix_ensemble`), which evaluated to `False` for single-CRS runs. Patches written to `SUBMIT_DIR` were never copied to `EXCHANGE_DIR`, so CRSBench saw 0 patches.