### PR TITLE
docs: mention dotenv support for LLM env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ uv run oss-crs run \
 For a more advanced CRS that leverages LLMs, you can use **atlantis-multilang**. This CRS supports multiple languages and uses an LLM to generate and refine fuzz harnesses.
 See [`./example/multilang/multilang-compose.yaml`](example/multilang/multilang-compose.yaml) for the full configuration.
 
+> **Environment variables:** For LLM-backed runs, you can either `export` provider credentials in your shell or place them in a `.env` file in the directory where you run `oss-crs`. The CLI loads `.env` automatically via dotenv before parsing the compose file.
+
 ```bash
 # Prepare the LLM-powered CRS, for example, multilang
 uv run oss-crs prepare \
@@ -72,6 +74,7 @@ uv run oss-crs build-target \
 export OPENAI_API_KEY=<OPENAI_API_KEY>
 export GEMINI_API_KEY=<GEMINI_API_KEY>
 export ANTHROPIC_API_KEY=<ANTHROPIC_API_KEY>
+# Or put the same variables in .env and skip the export lines.
 uv run oss-crs run \
   --compose-file ./example/multilang/multilang-compose.yaml \
   --fuzz-proj-path ~/oss-fuzz/projects/libxml2 \
@@ -129,6 +132,7 @@ uv run oss-crs build-target \
 export OPENAI_API_KEY=<OPENAI_API_KEY>
 export GEMINI_API_KEY=<GEMINI_API_KEY>
 export ANTHROPIC_API_KEY=<ANTHROPIC_API_KEY>
+# Or put the same variables in .env and skip the export lines.
 uv run oss-crs run \
   --compose-file ./example/ensemble/ensemble-compose.yaml  \
   --fuzz-proj-path ~/oss-fuzz/projects/libxml2 \

--- a/docs/config/llm.md
+++ b/docs/config/llm.md
@@ -9,7 +9,7 @@ For complete documentation, refer to:
 - [LiteLLM Proxy Configuration](https://docs.litellm.ai/docs/proxy/configs)
 - [LiteLLM Supported Providers](https://docs.litellm.ai/docs/providers)
 
-> **Note:** Use `os.environ/VAR_NAME` format to reference environment variables (e.g., `os.environ/OPENAI_API_KEY`). OSS-CRS extracts these references and validates that the environment variables are set at runtime.
+> **Note:** Use `os.environ/VAR_NAME` format to reference environment variables (e.g., `os.environ/OPENAI_API_KEY`). OSS-CRS extracts these references and validates that the environment variables are set at runtime. You can satisfy them either by exporting variables in your shell or by putting them in a `.env` file in the directory where you run `oss-crs`; the CLI calls `load_dotenv()` automatically on startup.
 
 ---
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -6,6 +6,8 @@ The LiteLLM proxy can forward requests to any OpenAI-compatible servers. [vLLM](
 
 In OSS-CRS, you will want to set a custom LiteLLM proxy configuration.
 
+You can provide any referenced credentials either through exported shell variables or a `.env` file in the directory where you run `oss-crs`. The CLI loads `.env` automatically via dotenv.
+
 As documented in [LiteLLM Providers](https://docs.litellm.ai/docs/providers/openai_compatible#usage-with-litellm-proxy-server), the important part is to prefix your available model names with `openai/` for `model_list[].litellm_params.model`. However, you can still use your original model name or alias them with `model_list[].model_name`.
 
 ```yaml example/test-local/litellm-config.yaml
@@ -78,6 +80,7 @@ You'll need to first update `example/test-local/litellm-config.yaml` with your k
 ```sh
 # Set LLM key (can rename environment variable, see NOTE in litellm-config.yaml)
 export VLLM_KEY=<SECRET_KEY>
+# Or place VLLM_KEY=<SECRET_KEY> in .env and run the same commands below.
 
 # Prepare the CRS
 uv run oss-crs prepare --compose-file example/test-local/compose.yaml


### PR DESCRIPTION
https://github.com/sslab-gatech/oss-crs/blob/f1c3c6e5e7b1c4aa7f496be665b029b2a0e7f748/oss_crs/src/cli/crs_compose.py#L302

We support .env; but it's not documented. Added that.