### PR TITLE
feat(builder-sidecar): log API calls to LOG_DIR for evaluation

### DIFF
--- a/oss_crs/src/templates/oss_crs_builder_server.py
+++ b/oss_crs/src/templates/oss_crs_builder_server.py
@@ -19,14 +19,17 @@ from fastapi import FastAPI, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import hashlib
+import json
 import os
 import queue
 import re
 import shutil
 import subprocess
 import threading
+import time
 import uuid
 from pathlib import Path
+from typing import Optional
 
 app = FastAPI(title="Builder Sidecar", description="Incremental patch build server")
 job_queue: queue.Queue = queue.Queue()
@@ -35,6 +38,37 @@ job_results: dict = {}
 BUILDS_DIR = Path("/builds")
 PREBUILT_OUT_DIR = Path("/OSS_CRS_BUILD_OUT_DIR/build")
 OSS_CRS_PROJ_PATH = Path(os.environ.get("OSS_CRS_PROJ_PATH", "/OSS_CRS_PROJ_PATH"))
+
+# API call log — local path symlinked to OSS_CRS_LOG_DIR by libCRS register-log-dir.
+_API_LOG_DIR = Path("/sidecar-logs")
+_API_LOG_FILE: Optional[Path] = None
+
+
+def _init_api_log() -> None:
+    """Register a log directory and set up the API call log file."""
+    global _API_LOG_FILE
+    try:
+        subprocess.run(
+            ["libCRS", "register-log-dir", str(_API_LOG_DIR)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        _API_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    _API_LOG_FILE = _API_LOG_DIR / "api-calls.jsonl"
+    _API_LOG_FILE.touch(exist_ok=True)
+
+
+def _log_api_call(entry: dict) -> None:
+    """Append one JSON line to the API call log."""
+    if _API_LOG_FILE is None:
+        return
+    try:
+        with _API_LOG_FILE.open("a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except Exception:
+        pass  # best-effort logging
 
 
 def _ignore_build_junk(directory, contents):
@@ -271,8 +305,10 @@ def _handle_run_pov(job_id: str, req_dir: Path, resp_dir: Path) -> dict:
     pov_timeout = int(os.environ.get("POV_TIMEOUT", "30"))
 
     build_out = BUILDS_DIR / build_id / "out"
+    base = {"harness": harness_name, "build_id": build_id}
     if not (build_out / harness_name).exists():
         return {
+            **base,
             "pov_exit_code": 127,
             "pov_stderr": f"Harness binary not found: {build_out / harness_name}",
         }
@@ -294,12 +330,14 @@ def _handle_run_pov(job_id: str, req_dir: Path, resp_dir: Path) -> dict:
             cwd=str(build_out),
         )
         return {
+            **base,
             "pov_exit_code": result.returncode,
             "pov_stderr": result.stderr,
             "pov_stdout": result.stdout,
         }
     except subprocess.TimeoutExpired:
         return {
+            **base,
             "pov_exit_code": 124,
             "pov_stdout": "",
             "pov_stderr": "POV execution timed out",
@@ -311,10 +349,13 @@ def _handle_run_test(job_id: str, req_dir: Path, resp_dir: Path) -> dict:
     build_id = (req_dir / "build_id").read_text().strip()
     test_timeout = int(os.environ.get("TEST_TIMEOUT", "120"))
 
+    base = {"build_id": build_id}
     test_path = OSS_CRS_PROJ_PATH / "test.sh"
     if not test_path.exists():
         return {
+            **base,
             "test_exit_code": 0,
+            "test_skipped": True,
             "test_stdout": "",
             "test_stderr": f"skipped: no test.sh found in {OSS_CRS_PROJ_PATH}/",
         }
@@ -333,13 +374,17 @@ def _handle_run_test(job_id: str, req_dir: Path, resp_dir: Path) -> dict:
             cwd=str(build_out),
         )
         return {
+            **base,
             "test_exit_code": result.returncode,
+            "test_skipped": False,
             "test_stdout": result.stdout,
             "test_stderr": result.stderr,
         }
     except subprocess.TimeoutExpired as exc:
         return {
+            **base,
             "test_exit_code": 124,
+            "test_skipped": False,
             "test_stdout": exc.stdout or "",
             "test_stderr": "Test execution timed out",
         }
@@ -357,23 +402,78 @@ def job_worker():
     while True:
         action, job_id, req_dir, resp_dir = job_queue.get()
         job_results[job_id]["status"] = "running"
+        ts_start = time.time()
+        t0 = time.monotonic()
+        result: dict = {}
         try:
             handler = _HANDLERS[action]
             result = handler(job_id, req_dir, resp_dir)
             job_results[job_id] = {"id": job_id, "status": "done", **result}
         except Exception as e:
+            result = {"error": str(e)}
             job_results[job_id] = {
                 "id": job_id,
                 "status": "done",
                 "error": str(e),
             }
         finally:
+            duration_ms = int((time.monotonic() - t0) * 1000)
+            _log_api_call(
+                _make_log_entry(action, job_id, result, duration_ms, ts_start)
+            )
             shutil.rmtree(req_dir.parent, ignore_errors=True)
             job_queue.task_done()
 
 
+_EXIT_CODE_KEYS = {
+    "build": "build_exit_code",
+    "run-pov": "pov_exit_code",
+    "run-test": "test_exit_code",
+}
+
+
+def _make_log_entry(
+    action: str,
+    job_id: str,
+    result: dict,
+    duration_ms: int,
+    ts_start: float,
+) -> dict:
+    """Create a structured log entry for an API call."""
+    exit_code = result.get(_EXIT_CODE_KEYS.get(action, ""), -1)
+    entry: dict = {
+        "ts": ts_start,
+        "api": action,
+        "job_id": job_id,
+        "duration_ms": duration_ms,
+        "exit_code": exit_code,
+    }
+    # Include request params returned by handlers
+    for key in ("harness", "build_id"):
+        if key in result:
+            entry[key] = result[key]
+    # Propagate handler errors (unhandled exceptions)
+    if "error" in result:
+        entry["error"] = result["error"]
+    # API-specific derived fields for consumer convenience
+    # exit_code > 0 guards against the -1 sentinel from handler exceptions
+    if action == "build":
+        entry["build_success"] = exit_code == 0
+    elif action == "run-pov":
+        entry["crash"] = exit_code > 0 and exit_code != 124
+        entry["timeout"] = exit_code == 124
+    elif action == "run-test":
+        entry["test_passed"] = exit_code == 0
+        entry["skipped"] = bool(result.get("test_skipped"))
+    return entry
+
+
 if __name__ == "__main__":
     import uvicorn
+
+    # Register API call log directory via libCRS so logs are persisted
+    # to the host-mounted LOG_DIR and survive container termination.
+    _init_api_log()
 
     # Register /builds as a shared directory via libCRS so artifacts
     # are visible to CRS modules through the shared filesystem.

--- a/oss_crs/tests/unit/test_builder_sidecar_logging.py
+++ b/oss_crs/tests/unit/test_builder_sidecar_logging.py
@@ -1,0 +1,260 @@
+"""Unit tests for builder sidecar API call logging.
+
+NOTE: The _make_log_entry function is duplicated here because the template
+file (oss_crs_builder_server.py) imports FastAPI which is not available in
+the test environment. If the implementation changes, these tests must be
+updated to match. The canonical source is:
+  oss_crs/src/templates/oss_crs_builder_server.py
+"""
+
+import json
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Duplicated from oss_crs_builder_server.py (see NOTE above)
+# ---------------------------------------------------------------------------
+
+_EXIT_CODE_KEYS = {
+    "build": "build_exit_code",
+    "run-pov": "pov_exit_code",
+    "run-test": "test_exit_code",
+}
+
+
+def _make_log_entry(
+    action: str,
+    job_id: str,
+    result: dict,
+    duration_ms: int,
+    ts_start: float,
+) -> dict:
+    """Create a structured log entry for an API call."""
+    exit_code = result.get(_EXIT_CODE_KEYS.get(action, ""), -1)
+    entry: dict = {
+        "ts": ts_start,
+        "api": action,
+        "job_id": job_id,
+        "duration_ms": duration_ms,
+        "exit_code": exit_code,
+    }
+    for key in ("harness", "build_id"):
+        if key in result:
+            entry[key] = result[key]
+    if "error" in result:
+        entry["error"] = result["error"]
+    if action == "build":
+        entry["build_success"] = exit_code == 0
+    elif action == "run-pov":
+        entry["crash"] = exit_code > 0 and exit_code != 124
+        entry["timeout"] = exit_code == 124
+    elif action == "run-test":
+        entry["test_passed"] = exit_code == 0
+        entry["skipped"] = bool(result.get("test_skipped"))
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_log_entry
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLogEntryBuild:
+    """Tests for build API log entries."""
+
+    def test_success(self):
+        e = _make_log_entry("build", "abc123", {"build_exit_code": 0}, 8920, 1000.0)
+        assert e["api"] == "build"
+        assert e["exit_code"] == 0
+        assert e["build_success"] is True
+        assert e["ts"] == 1000.0
+        assert e["duration_ms"] == 8920
+
+    def test_failure(self):
+        e = _make_log_entry("build", "def456", {"build_exit_code": 1}, 5000, 1000.0)
+        assert e["build_success"] is False
+
+    def test_no_build_id_in_entry(self):
+        """Build entries use job_id as build_id; no separate build_id field."""
+        e = _make_log_entry("build", "abc123", {"build_exit_code": 0}, 100, 1000.0)
+        assert "build_id" not in e
+
+    def test_handler_exception(self):
+        e = _make_log_entry("build", "j1", {"error": "compile crashed"}, 100, 1000.0)
+        assert e["exit_code"] == -1
+        assert e["build_success"] is False
+        assert e["error"] == "compile crashed"
+
+
+class TestMakeLogEntryRunPov:
+    """Tests for run-pov API log entries."""
+
+    def test_crash(self):
+        result = {"pov_exit_code": 1, "harness": "html", "build_id": "base"}
+        e = _make_log_entry("run-pov", "p1", result, 2340, 1000.0)
+        assert e["crash"] is True
+        assert e["timeout"] is False
+        assert e["harness"] == "html"
+        assert e["build_id"] == "base"
+
+    def test_no_crash(self):
+        result = {"pov_exit_code": 0, "harness": "fuzz", "build_id": "abc"}
+        e = _make_log_entry("run-pov", "p2", result, 1500, 1000.0)
+        assert e["crash"] is False
+        assert e["timeout"] is False
+
+    def test_timeout(self):
+        result = {"pov_exit_code": 124, "harness": "fuzz", "build_id": "base"}
+        e = _make_log_entry("run-pov", "p3", result, 30000, 1000.0)
+        assert e["crash"] is False
+        assert e["timeout"] is True
+        assert e["exit_code"] == 124
+
+    def test_exit_77_is_crash(self):
+        """Exit 77 = libFuzzer security finding, should be classified as crash."""
+        result = {"pov_exit_code": 77, "harness": "fuzz", "build_id": "base"}
+        e = _make_log_entry("run-pov", "p4", result, 100, 1000.0)
+        assert e["crash"] is True
+        assert e["exit_code"] == 77
+
+    def test_handler_exception_not_crash(self):
+        """Handler exception (exit_code=-1) must not be classified as crash."""
+        e = _make_log_entry(
+            "run-pov", "p5", {"error": "connection refused"}, 100, 1000.0
+        )
+        assert e["crash"] is False
+        assert e["exit_code"] == -1
+        assert e["error"] == "connection refused"
+
+    def test_harness_not_found(self):
+        """Exit 127 = harness binary missing, still classified as crash."""
+        result = {"pov_exit_code": 127, "harness": "missing", "build_id": "base"}
+        e = _make_log_entry("run-pov", "p6", result, 50, 1000.0)
+        assert e["crash"] is True
+        assert e["harness"] == "missing"
+
+
+class TestMakeLogEntryRunTest:
+    """Tests for run-test API log entries."""
+
+    def test_pass(self):
+        result = {"test_exit_code": 0, "test_skipped": False, "build_id": "abc"}
+        e = _make_log_entry("run-test", "t1", result, 45000, 1000.0)
+        assert e["test_passed"] is True
+        assert e["skipped"] is False
+        assert e["build_id"] == "abc"
+
+    def test_fail(self):
+        result = {"test_exit_code": 1, "test_skipped": False, "build_id": "abc"}
+        e = _make_log_entry("run-test", "t2", result, 30000, 1000.0)
+        assert e["test_passed"] is False
+        assert e["skipped"] is False
+
+    def test_skipped(self):
+        result = {"test_exit_code": 0, "test_skipped": True, "build_id": "abc"}
+        e = _make_log_entry("run-test", "t3", result, 50, 1000.0)
+        assert e["test_passed"] is True
+        assert e["skipped"] is True
+
+    def test_handler_exception(self):
+        e = _make_log_entry("run-test", "t4", {"error": "timeout"}, 100, 1000.0)
+        assert e["exit_code"] == -1
+        assert e["test_passed"] is False
+        assert e["error"] == "timeout"
+
+
+class TestMakeLogEntryCommon:
+    """Tests for common log entry fields."""
+
+    def test_timestamp_is_start_time(self):
+        ts = 1774296986.79
+        e = _make_log_entry("build", "j1", {"build_exit_code": 0}, 1000, ts)
+        assert e["ts"] == ts
+
+    def test_required_fields_present(self):
+        for action, result in [
+            ("build", {"build_exit_code": 0}),
+            ("run-pov", {"pov_exit_code": 1, "harness": "h", "build_id": "b"}),
+            ("run-test", {"test_exit_code": 0, "test_skipped": False, "build_id": "b"}),
+        ]:
+            e = _make_log_entry(action, "j1", result, 100, 1000.0)
+            assert all(
+                k in e for k in ("ts", "api", "job_id", "duration_ms", "exit_code")
+            )
+
+    def test_all_entries_json_serializable(self):
+        entries = [
+            _make_log_entry("build", "j1", {"build_exit_code": 0}, 100, 1000.0),
+            _make_log_entry(
+                "run-pov",
+                "j2",
+                {"pov_exit_code": 1, "harness": "h", "build_id": "b"},
+                100,
+                1000.0,
+            ),
+            _make_log_entry(
+                "run-test",
+                "j3",
+                {"test_exit_code": 0, "test_skipped": False, "build_id": "b"},
+                100,
+                1000.0,
+            ),
+            _make_log_entry("run-pov", "j4", {"error": "fail"}, 100, 1000.0),
+        ]
+        for entry in entries:
+            line = json.dumps(entry)
+            assert json.loads(line) == entry
+
+    def test_unknown_action(self):
+        e = _make_log_entry("unknown", "j1", {}, 100, 1000.0)
+        assert e["exit_code"] == -1
+        assert "crash" not in e
+        assert "build_success" not in e
+        assert "test_passed" not in e
+
+
+# ---------------------------------------------------------------------------
+# Tests: JSONL file writing
+# ---------------------------------------------------------------------------
+
+
+class TestLogApiCallFile:
+    """Tests for JSONL file writing mechanics."""
+
+    def _write_entry(self, log_file: Path, entry: dict) -> None:
+        with log_file.open("a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+    def test_writes_jsonl_lines(self, tmp_path):
+        log_file = tmp_path / "api-calls.jsonl"
+        log_file.touch()
+        self._write_entry(log_file, {"api": "build", "exit_code": 0})
+        self._write_entry(log_file, {"api": "run-pov", "exit_code": 1})
+
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert json.loads(lines[0])["api"] == "build"
+        assert json.loads(lines[1])["api"] == "run-pov"
+
+    def test_empty_file_means_zero_calls(self, tmp_path):
+        log_file = tmp_path / "api-calls.jsonl"
+        log_file.touch()
+        assert log_file.exists()
+        assert log_file.read_text() == ""
+
+    def test_compact_json_no_spaces(self, tmp_path):
+        log_file = tmp_path / "api-calls.jsonl"
+        log_file.touch()
+        self._write_entry(log_file, {"api": "build", "exit_code": 0})
+        line = log_file.read_text().strip()
+        assert " " not in line  # compact separators
+
+    def test_each_line_is_valid_json(self, tmp_path):
+        log_file = tmp_path / "api-calls.jsonl"
+        log_file.touch()
+        for i in range(5):
+            self._write_entry(log_file, {"api": "run-pov", "n": i})
+        lines = log_file.read_text().strip().split("\n")
+        assert len(lines) == 5
+        for line in lines:
+            json.loads(line)  # should not raise


### PR DESCRIPTION
## Summary

Add structured JSONL logging of every builder sidecar API call (`run-pov`, `apply-patch-build`, `run-test`) to `OSS_CRS_LOG_DIR` for CRS evaluation.

Closes #148

## Implementation

- Register `/sidecar-logs` via `libCRS register-log-dir` at startup, symlinked to host-mounted `OSS_CRS_LOG_DIR`
- After each API handler completes, append one JSON line to `api-calls.jsonl`
- Each entry includes: `ts`, `api`, `job_id`, `exit_code`, `duration_ms`, plus api-specific fields
- Handlers return `harness`/`build_id` in result dicts (no separate pre-read needed)
- `crash` uses `exit_code > 0` to avoid false positives from handler exceptions (sentinel `-1`)
- Empty `api-calls.jsonl` created at startup to distinguish "zero calls" from "sidecar never started"
- Best-effort logging — never blocks or fails the API call

## Log entry examples

**Bug-finding** (crs-bug-finding-claude-code on sanity-mock-c-delta-01):
```jsonl
{"ts":1774296986.79,"api":"run-pov","job_id":"2b9ec6bf26cf","duration_ms":58,"exit_code":1,"harness":"fuzz_parse_buffer_section","build_id":"base","crash":true,"timeout":false}
{"ts":1774297023.24,"api":"run-pov","job_id":"dbe6bf714002","duration_ms":55,"exit_code":1,"harness":"fuzz_parse_buffer_section","build_id":"base","crash":true,"timeout":false}
{"ts":1774297067.71,"api":"run-pov","job_id":"bcee79ed184a","duration_ms":65,"exit_code":77,"harness":"fuzz_parse_buffer_section","build_id":"base","crash":true,"timeout":false}
```

**Bug-fixing** (crs-claude-code on sanity-mock-c-delta-01 with POV input):
```jsonl
{"ts":1774300121.36,"api":"build","job_id":"52d872574bec","duration_ms":551,"exit_code":0,"build_success":true}
{"ts":1774300136.70,"api":"run-pov","job_id":"d9f4cce856b6","duration_ms":107,"exit_code":1,"harness":"fuzz_parse_buffer_section","build_id":"base","crash":true,"timeout":false}
{"ts":1774300148.91,"api":"run-pov","job_id":"21fc5831ed93","duration_ms":90,"exit_code":0,"harness":"fuzz_parse_buffer_section","build_id":"52d872574bec","crash":false,"timeout":false}
{"ts":1774300159.91,"api":"run-test","job_id":"bd45c2ec677e","duration_ms":176,"exit_code":0,"build_id":"52d872574bec","test_passed":true,"skipped":false}
```

## Log file location

```
<workdir>/.../LOG_DIR/<harness>/sidecar-logs/api-calls.jsonl
```

Collected by `oss-crs artifacts` via the `log_dir` field, and by CRSBench adapter to `trial_dir/output/logs/crs/<crs>/log_dir/sidecar-logs/api-calls.jsonl`.

## Smoke test results

Tested against `sanity-mock-c-delta-01` (`fuzz_parse_buffer_section` harness):

| CRS | Bug-finding | Bug-fixing (with POV) |
|---|---|---|
| crs-bug-finding-claude-code | 7 run-pov, all crashes | — |
| crs-bug-finding-codex | 6 run-pov, all crashes | — |
| crs-bug-finding-copilot-cli | 5 run-pov, all crashes | — |
| crs-bug-finding-gemini-cli | 10 run-pov, all crashes | — |
| crs-claude-code | — | 4 calls: build→run-pov(crash)→run-pov(no crash)→run-test(pass) |
| crs-codex | — | 4 calls: run-pov(crash)→build→run-pov(no crash)→run-test(pass) |
| crs-copilot-cli | — | 3 calls: build→run-pov(no crash)→run-test(pass) |
| crs-gemini-cli | — | 3 calls: build→run-pov(no crash)→run-test(pass) |

## Test plan

- [x] 22 unit tests for log entry construction and JSONL writing
- [x] Smoke tested crs-bug-finding-claude-code, crs-bug-finding-codex, crs-bug-finding-copilot-cli, crs-bug-finding-gemini-cli in bug-finding mode (real Docker runs)
- [x] Smoke tested crs-claude-code, crs-codex, crs-copilot-cli, crs-gemini-cli in bug-fixing mode with POV input (real Docker runs)
- [x] Verified `api-calls.jsonl` persists in LOG_DIR on host
- [x] Verified `oss-crs artifacts` reports `log_dir` containing the file