### PR TITLE
chore: update atlantis-java repo url

### DIFF
--- a/example/atlantis-java-main/compose.yaml
+++ b/example/atlantis-java-main/compose.yaml
@@ -18,7 +18,7 @@ oss_crs_infra:
 # generation, exploitation kit (expkit), static analysis, CodeQL, and more.
 atlantis-java-main:
   source:
-    local_path: /tmp/atlantis-java-snapshot
+    local_path: /tmp/atlantis-java
   cpuset: "4-11"
   memory: "32G"
   llm_budget: 100

--- a/registry/atlantis-java-main.yaml
+++ b/registry/atlantis-java-main.yaml
@@ -2,5 +2,5 @@ name: atlantis-java-main
 type:
   - bug-finding
 source:
-  url: https://github.com/Team-Atlanta/atlantis-java-snapshot.git
+  url: https://github.com/Team-Atlanta/atlantis-java.git
   ref: main


### PR DESCRIPTION
## Summary

Update atlantis-java repo url from `atlantis-java-snapshot` to `atlantis-java` after moving the repository.