### PR TITLE
fix: use Docker Compose secrets for LLM keys (#160)

### DIFF
--- a/docs/crs-development-guide.md
+++ b/docs/crs-development-guide.md
@@ -330,7 +330,7 @@ Notes:
 | Variable | Description |
 |---|---|
 | `OSS_CRS_LLM_API_URL` | LiteLLM proxy endpoint (e.g., `http://litellm.oss-crs:4000`) |
-| `OSS_CRS_LLM_API_KEY` | Per-CRS API key for LLM access |
+| `OSS_CRS_LLM_API_KEY_FILE` | Path to file containing per-CRS API key for LLM access |
 
 Use these with any OpenAI-compatible client library. All requests are proxied through LiteLLM, which enforces your budget.
 
@@ -688,8 +688,11 @@ At runtime, use the provided environment variables with any OpenAI-compatible cl
 from openai import OpenAI
 import os
 
+with open(os.environ["OSS_CRS_LLM_API_KEY_FILE"]) as f:
+    api_key = f.read().strip()
+
 client = OpenAI(
-    api_key=os.environ["OSS_CRS_LLM_API_KEY"],
+    api_key=api_key,
     base_url=os.environ["OSS_CRS_LLM_API_URL"],
 )
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -190,7 +190,7 @@ oss-crs-infra provides centralized services that all CRSs share. It runs in its 
 The LLM subsystem uses [LiteLLM](https://github.com/BerriAI/litellm) as a proxy:
 
 - **Unified API**: CRSs send requests to a single endpoint (`$OSS_CRS_LLM_API_URL`), abstracting all model providers (OpenAI, Anthropic, Google, etc.)
-- **Per-CRS API Keys**: Each CRS receives a unique `$OSS_CRS_LLM_API_KEY` at launch
+- **Per-CRS API Keys**: Each CRS receives a unique API key via a Docker secret file at `$OSS_CRS_LLM_API_KEY_FILE`
 - **Budget Enforcement**: Dollar-denominated limits per CRS, tracked in PostgreSQL
 - **Model Routing**: Logical model names are mapped to provider-specific models via LiteLLM config
 
@@ -198,7 +198,7 @@ LLM setup flow during `oss-crs run`:
 
 1. CRS Compose generates per-CRS API keys
 2. The `litellm-key-gen` service registers keys and budgets in LiteLLM
-3. CRS containers receive their API key via `OSS_CRS_LLM_API_KEY` and endpoint via `OSS_CRS_LLM_API_URL`
+3. CRS containers receive their API key as a Docker secret via `OSS_CRS_LLM_API_KEY_FILE` and endpoint via `OSS_CRS_LLM_API_URL`
 4. All LLM requests are proxied through LiteLLM, which enforces budgets and logs usage
 
 `required_llms` is only used for model-availability validation; internal per-CRS key generation does not depend on `required_llms` being set.
@@ -206,7 +206,7 @@ LLM setup flow during `oss-crs run`:
 LiteLLM integration modes:
 
 - **Internal mode**: OSS-CRS starts LiteLLM/PostgreSQL/key-gen sidecars and injects per-CRS API keys.
-- **External mode**: OSS-CRS injects externally provided `OSS_CRS_LLM_API_URL` / `OSS_CRS_LLM_API_KEY`, and does not start internal LiteLLM sidecars.
+- **External mode**: OSS-CRS injects externally provided `OSS_CRS_LLM_API_URL` / `OSS_CRS_LLM_API_KEY_FILE`, and does not start internal LiteLLM sidecars.
 - **Disabled mode** (`llm_config: null`): OSS-CRS performs no LiteLLM validation or sidecar setup.
 
 ### Pinned Infrastructure Images

--- a/oss-crs-infra/litellm-key-gen/main.py
+++ b/oss-crs-infra/litellm-key-gen/main.py
@@ -3,7 +3,17 @@ import os
 import yaml
 import requests
 
-LITELLM_MASTER_KEY = os.getenv("LITELLM_MASTER_KEY")
+
+def _read_secret(path: str) -> str | None:
+    """Read a Docker secret file."""
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return None
+
+
+LITELLM_MASTER_KEY = _read_secret("/run/secrets/litellm_master_key")
 LITELLM_API_URL = os.getenv("LITELLM_API_URL")
 
 

--- a/oss-crs-infra/litellm-key-gen/main.py
+++ b/oss-crs-infra/litellm-key-gen/main.py
@@ -4,13 +4,10 @@ import yaml
 import requests
 
 
-def _read_secret(path: str) -> str | None:
+def _read_secret(path: str) -> str:
     """Read a Docker secret file."""
-    try:
-        with open(path) as f:
-            return f.read().strip()
-    except FileNotFoundError:
-        return None
+    with open(path) as f:
+        return f.read().strip()
 
 
 LITELLM_MASTER_KEY = _read_secret("/run/secrets/litellm_master_key")

--- a/oss_crs/src/env_policy.py
+++ b/oss_crs/src/env_policy.py
@@ -189,7 +189,7 @@ def build_run_service_env(
     if llm_api_url:
         system_env["OSS_CRS_LLM_API_URL"] = llm_api_url
     if llm_api_key:
-        system_env["OSS_CRS_LLM_API_KEY"] = llm_api_key
+        system_env["OSS_CRS_LLM_API_KEY_FILE"] = "/run/secrets/oss_crs_llm_api_key"
 
     return _resolve_env(
         phase="run",

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -166,13 +166,21 @@ def prepare_llm_context(
             raise RuntimeError("External LiteLLM URL is required.")
         if not key:
             raise RuntimeError("External LiteLLM API key is required.")
+        tmp_dir = tmp_docker_compose.dir
+        if tmp_dir is None:
+            raise RuntimeError("Temporary docker compose directory was not initialized")
         keys = {}
+        secret_files = {}
         for crs in crs_compose.crs_list:
             keys[crs.name] = key
+            key_file = tmp_dir / f"oss_crs_llm_api_key_{crs.name}"
+            key_file.write_text(key)
+            secret_files[crs.name] = str(key_file)
         return {
             "mode": "external",
             "llm_api_url": url,
             "api_keys": keys,
+            "secret_files": secret_files,
         }
 
     if crs_compose.llm.mode == "internal":
@@ -208,15 +216,31 @@ def prepare_llm_context(
             yaml.dump(key_info, default_flow_style=False, sort_keys=False)
         )
 
+        # Write secrets to files for Docker Compose secrets
+        master_key = "sk-" + _generate_random_key(16)
+        master_key_file = tmp_dir / "litellm_master_key"
+        master_key_file.write_text(master_key)
+
+        postgres_password = _generate_random_key(16)
+        postgres_password_file = tmp_dir / "postgres_password"
+        postgres_password_file.write_text(postgres_password)
+
+        secret_files = {}
+        for crs_name, crs_key in keys.items():
+            key_file = tmp_dir / f"oss_crs_llm_api_key_{crs_name}"
+            key_file.write_text(crs_key)
+            secret_files[crs_name] = str(key_file)
+
         return {
             "mode": "internal",
             "llm_api_url": LITELLM_INTERNAL_URL,
-            "litellm_master_key": "sk-" + _generate_random_key(16),
-            "postgres_password": _generate_random_key(16),
+            "master_key_file": str(master_key_file),
+            "postgres_password_file": str(postgres_password_file),
             "litellm_config_path": llm_config.litellm.internal.config_path
             if llm_config.litellm.internal and llm_config.litellm.internal.config_path
             else str(DEFAULT_LITELLM_CONFIG_PATH),
             "api_keys": keys,
+            "secret_files": secret_files,
             "litellm_env": litellm_env,
             "key_gen_request_path": str(key_gen_request_path),
         }

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -188,14 +188,16 @@ def prepare_llm_context(
         tmp_dir = tmp_docker_compose.dir
         if tmp_dir is None:
             raise RuntimeError("Temporary docker compose directory was not initialized")
-        litellm_env = {}
+        litellm_env_secret_files = {}
         for name in crs_compose.llm.extract_envs():
             tmp = os.environ.get(name)
             if tmp is None:
                 raise RuntimeError(
                     f"Environment variable '{name}' required by LiteLLM config is not set."
                 )
-            litellm_env[name] = tmp
+            secret_file = tmp_dir / f"litellm_env_{name}"
+            secret_file.write_text(tmp)
+            litellm_env_secret_files[name] = str(secret_file)
         # Generate keys for each CRS
         keys = {}
         key_info = {}
@@ -241,7 +243,7 @@ def prepare_llm_context(
             else str(DEFAULT_LITELLM_CONFIG_PATH),
             "api_keys": keys,
             "secret_files": secret_files,
-            "litellm_env": litellm_env,
+            "litellm_env_secret_files": litellm_env_secret_files,
             "key_gen_request_path": str(key_gen_request_path),
         }
 

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -31,14 +31,22 @@ services:
       args:
         - target_base_image={{target.get_docker_image_name()}}
         - crs_version={{ crs.config.version }}
+{%- if snapshot_image_tag and (module_config.run_snapshot or crs.config.is_builder) %}
+        - snapshot_image={{ snapshot_image_tag }}
+{%- endif %}
     environment:
 {%- for env_key, env_value in module_envs[crs.name + "_" + module_name].items() %}
       - {{ env_key }}={{ env_value }}
 {%- endfor %}
-{%- if llm_context is defined and llm_context.mode == "internal" %}
+{%- if llm_context is defined and llm_context.mode == "internal" and not crs.config.is_builder %}
     depends_on:
       oss-crs-litellm-key-gen:
         condition: service_completed_successfully
+{%- endif %}
+{%- if llm_context is defined and crs.name in llm_context.secret_files %}
+    secrets:
+      - source: oss_crs_llm_api_key_{{ crs.name }}
+        target: oss_crs_llm_api_key
 {%- endif %}
 {%- if cgroup_parents and crs.name in cgroup_parents %}
     # Using cgroup-parent mode: resources managed by parent cgroup
@@ -84,12 +92,15 @@ services:
     depends_on:
       oss-crs-postgres:
         condition: service_healthy
+{%- if llm_context.litellm_env %}
     environment:
-      - LITELLM_MASTER_KEY={{ llm_context.litellm_master_key }}
-      - DATABASE_URL=postgresql://{{ postgres_user }}:{{ llm_context.postgres_password }}@{{ postgres_host }}:{{ postgres_port }}/{{ postgres_user }}
     {%- for key, value in llm_context.litellm_env.items() %}
       - {{ key }}={{ value }}
     {%- endfor %}
+{%- endif %}
+    secrets:
+      - litellm_master_key
+      - postgres_password
     volumes:
       - {{ llm_context.litellm_config_path }}:/app/config.yaml:ro
     networks:
@@ -97,7 +108,12 @@ services:
       {{ crs_compose_name }}-network:
         aliases:
           - litellm.oss-crs
-    command: --config /app/config.yaml
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        export LITELLM_MASTER_KEY=$$(cat /run/secrets/litellm_master_key)
+        && export DATABASE_URL=postgresql://{{ postgres_user }}:$$(cat /run/secrets/postgres_password)@{{ postgres_host }}:{{ postgres_port }}/{{ postgres_user }}
+        && exec litellm --config /app/config.yaml
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\""]
       interval: 5s
@@ -110,7 +126,9 @@ services:
     restart: on-failure:3
     environment:
       - POSTGRES_USER={{ postgres_user }}
-      - POSTGRES_PASSWORD={{ llm_context.postgres_password }}
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+    secrets:
+      - postgres_password
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U {{ postgres_user }} -h localhost -p {{ postgres_port }}"]
       interval: 5s
@@ -130,8 +148,9 @@ services:
       oss-crs-litellm:
         condition: service_healthy
     environment:
-      - LITELLM_MASTER_KEY={{ llm_context.litellm_master_key }}
       - LITELLM_API_URL={{ litellm_internal_url }}
+    secrets:
+      - litellm_master_key
     networks:
       {{ crs_compose_name }}-network:
     volumes:
@@ -160,7 +179,7 @@ services:
   ###########################################
   # OSS-CRS-LIFECYCLE SIDECAR
   ###########################################
-{#- Collect non-builder, non-ensemble bug-fixing CRS services #}
+{#- Collect non-ensemble bug-fixing CRS services #}
 {%- set watch_services = [] %}
 {%- for crs in crs_list %}
 {%- if not crs.config.is_bug_fixing_ensemble and crs.config.is_bug_fixing %}
@@ -260,3 +279,16 @@ services:
 {%- for crs in crs_list %}
           - runner-sidecar.{{ crs.name }}
 {%- endfor %}
+{%- if llm_context is defined %}
+secrets:
+{%- if llm_context.mode == "internal" %}
+  litellm_master_key:
+    file: {{ llm_context.master_key_file }}
+  postgres_password:
+    file: {{ llm_context.postgres_password_file }}
+{%- endif %}
+{%- for crs_name, key_file in llm_context.secret_files.items() %}
+  oss_crs_llm_api_key_{{ crs_name }}:
+    file: {{ key_file }}
+{%- endfor %}
+{%- endif %}

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -31,14 +31,11 @@ services:
       args:
         - target_base_image={{target.get_docker_image_name()}}
         - crs_version={{ crs.config.version }}
-{%- if snapshot_image_tag and (module_config.run_snapshot or crs.config.is_builder) %}
-        - snapshot_image={{ snapshot_image_tag }}
-{%- endif %}
     environment:
 {%- for env_key, env_value in module_envs[crs.name + "_" + module_name].items() %}
       - {{ env_key }}={{ env_value }}
 {%- endfor %}
-{%- if llm_context is defined and llm_context.mode == "internal" and not crs.config.is_builder %}
+{%- if llm_context is defined and llm_context.mode == "internal" %}
     depends_on:
       oss-crs-litellm-key-gen:
         condition: service_completed_successfully
@@ -92,15 +89,13 @@ services:
     depends_on:
       oss-crs-postgres:
         condition: service_healthy
-{%- if llm_context.litellm_env %}
-    environment:
-    {%- for key, value in llm_context.litellm_env.items() %}
-      - {{ key }}={{ value }}
-    {%- endfor %}
-{%- endif %}
     secrets:
       - litellm_master_key
       - postgres_password
+{%- for env_name in llm_context.litellm_env_secret_files.keys() %}
+      - source: litellm_env_{{ env_name }}
+        target: litellm_env_{{ env_name }}
+{%- endfor %}
     volumes:
       - {{ llm_context.litellm_config_path }}:/app/config.yaml:ro
     networks:
@@ -113,6 +108,9 @@ services:
       - >-
         export LITELLM_MASTER_KEY=$$(cat /run/secrets/litellm_master_key)
         && export DATABASE_URL=postgresql://{{ postgres_user }}:$$(cat /run/secrets/postgres_password)@{{ postgres_host }}:{{ postgres_port }}/{{ postgres_user }}
+{%- for env_name in llm_context.litellm_env_secret_files.keys() %}
+        && export {{ env_name }}=$$(cat /run/secrets/litellm_env_{{ env_name }})
+{%- endfor %}
         && exec litellm --config /app/config.yaml
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\""]
@@ -179,7 +177,7 @@ services:
   ###########################################
   # OSS-CRS-LIFECYCLE SIDECAR
   ###########################################
-{#- Collect non-ensemble bug-fixing CRS services #}
+{#- Collect non-builder, non-ensemble bug-fixing CRS services #}
 {%- set watch_services = [] %}
 {%- for crs in crs_list %}
 {%- if not crs.config.is_bug_fixing_ensemble and crs.config.is_bug_fixing %}
@@ -286,6 +284,10 @@ secrets:
     file: {{ llm_context.master_key_file }}
   postgres_password:
     file: {{ llm_context.postgres_password_file }}
+{%- for env_name, secret_file in llm_context.litellm_env_secret_files.items() %}
+  litellm_env_{{ env_name }}:
+    file: {{ secret_file }}
+{%- endfor %}
 {%- endif %}
 {%- for crs_name, key_file in llm_context.secret_files.items() %}
   oss_crs_llm_api_key_{{ crs_name }}:

--- a/oss_crs/tests/unit/test_env_policy.py
+++ b/oss_crs/tests/unit/test_env_policy.py
@@ -190,7 +190,7 @@ def test_run_env_preserves_existing_precedence_and_system_wins() -> None:
     assert plan.effective_env["OSS_CRS_TARGET_HARNESS"] == "h1"
     assert plan.effective_env["OSS_CRS_FETCH_DIR"] == "/OSS_CRS_FETCH_DIR"
     assert plan.effective_env["OSS_CRS_LLM_API_URL"] == "http://llm"
-    assert plan.effective_env["OSS_CRS_LLM_API_KEY"] == "sk-test"
+    assert plan.effective_env["OSS_CRS_LLM_API_KEY_FILE"] == "/run/secrets/oss_crs_llm_api_key"
     assert plan.effective_env["BUILDER_MODULE"] == "builder-sidecar"
     assert any("ENV001" in warning for warning in plan.warnings)
 

--- a/oss_crs/tests/unit/test_env_policy.py
+++ b/oss_crs/tests/unit/test_env_policy.py
@@ -190,7 +190,10 @@ def test_run_env_preserves_existing_precedence_and_system_wins() -> None:
     assert plan.effective_env["OSS_CRS_TARGET_HARNESS"] == "h1"
     assert plan.effective_env["OSS_CRS_FETCH_DIR"] == "/OSS_CRS_FETCH_DIR"
     assert plan.effective_env["OSS_CRS_LLM_API_URL"] == "http://llm"
-    assert plan.effective_env["OSS_CRS_LLM_API_KEY_FILE"] == "/run/secrets/oss_crs_llm_api_key"
+    assert (
+        plan.effective_env["OSS_CRS_LLM_API_KEY_FILE"]
+        == "/run/secrets/oss_crs_llm_api_key"
+    )
     assert plan.effective_env["BUILDER_MODULE"] == "builder-sidecar"
     assert any("ENV001" in warning for warning in plan.warnings)
 

--- a/registry/crs-codex.yaml
+++ b/registry/crs-codex.yaml
@@ -3,4 +3,4 @@ type:
   - bug-fixing
 source:
   url: https://github.com/Team-Atlanta/crs-codex.git
-  ref: refactor/sidecar
+  ref: main


### PR DESCRIPTION
fix: use Docker Compose secrets for LLM keys

## Summary

Replace environment variable delivery of `LITELLM_MASTER_KEY`, `POSTGRES_PASSWORD`, and per-CRS `OSS_CRS_LLM_API_KEY` with Docker Compose file-based secrets per the Docker Compose secrets best practice
(https://docs.docker.com/compose/how-tos/use-secrets/).

Previously, sensitive LLM keys were injected as plaintext environment variables into containers. They are now delivered as Docker secrets mounted at `/run/secrets/`, preventing accidental exposure via `docker inspect`, logs, or child process env inheritance.

## User Impact

- [x] User-facing change

CRS authors who read `OSS_CRS_LLM_API_KEY` directly from the environment
must update to read from the file path provided by `OSS_CRS_LLM_API_KEY_FILE`:
Closes #160 
```python
# Before
api_key = os.environ["OSS_CRS_LLM_API_KEY"]

# After
with open(os.environ["OSS_CRS_LLM_API_KEY_FILE"]) as f:
    api_key = f.read().strip()
    
