### PR TITLE
fix(renderer): resolve oss-crs-infra: prefix in build-target context

### DIFF
--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -126,7 +126,9 @@ def render_build_target_docker_compose(
         "crs": {
             "name": crs.name,
             "path": str(crs.crs_path),
-            "builder_dockerfile": str(crs.crs_path / build_config.dockerfile),
+            "builder_dockerfile": _resolve_module_dockerfile(
+                crs.crs_path, build_config.dockerfile
+            ),
             "version": crs.config.version,
         },
         "effective_env": env_plan.effective_env,

--- a/oss_crs/tests/unit/test_renderer_build_target.py
+++ b/oss_crs/tests/unit/test_renderer_build_target.py
@@ -1,0 +1,112 @@
+"""Unit tests for ``render_build_target_docker_compose``.
+
+Focus: the ``crs.builder_dockerfile`` value rendered into the build-target
+docker-compose file must be resolved through ``_resolve_module_dockerfile``
+so that ``oss-crs-infra:<module>`` framework references expand to the infra
+Dockerfile path instead of being treated as a path under the CRS repo.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from oss_crs.src.templates.renderer import (
+    OSS_CRS_ROOT_PATH,
+    render_build_target_docker_compose,
+)
+
+
+def _patch_env(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "oss_crs.src.templates.renderer.build_target_builder_env",
+        lambda **_kwargs: SimpleNamespace(effective_env={"EXAMPLE": "1"}, warnings=[]),
+    )
+
+
+def _make_crs(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        name="crs-test",
+        crs_path=tmp_path,
+        crs_compose_env=SimpleNamespace(get_env=lambda: {"type": "local"}),
+        resource=SimpleNamespace(
+            cpuset="0-3",
+            memory="8G",
+            additional_env={},
+        ),
+        config=SimpleNamespace(version="1.0"),
+    )
+
+
+def _make_target(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        get_target_env=lambda: {"harness": "fuzz_target"},
+        proj_path=tmp_path / "proj",
+        repo_path=tmp_path / "repo",
+    )
+
+
+def _make_build_config(dockerfile: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name="inc-builder",
+        dockerfile=dockerfile,
+        outputs=["build"],
+        additional_env={},
+    )
+
+
+def _render(monkeypatch, tmp_path: Path, dockerfile: str) -> dict:
+    _patch_env(monkeypatch)
+    (tmp_path / "proj").mkdir()
+    (tmp_path / "repo").mkdir()
+    rendered, _warnings = render_build_target_docker_compose(
+        crs=_make_crs(tmp_path),
+        target=_make_target(tmp_path),
+        target_base_image="base:latest",
+        build_config=_make_build_config(dockerfile),
+        build_out_dir=tmp_path / "out",
+        build_id="build-1",
+        sanitizer="address",
+    )
+    return yaml.safe_load(rendered)
+
+
+def test_infra_prefix_resolves_to_framework_dockerfile_path(monkeypatch, tmp_path):
+    """``oss-crs-infra:<module>`` must resolve to the infra Dockerfile path."""
+    parsed = _render(monkeypatch, tmp_path, "oss-crs-infra:default-builder")
+
+    expected = str(
+        OSS_CRS_ROOT_PATH / "oss-crs-infra" / "default-builder" / "Dockerfile"
+    )
+    services = parsed["services"]
+    [(_name, svc)] = list(services.items())
+    assert svc["build"]["dockerfile"] == expected
+
+
+def test_plain_dockerfile_resolves_relative_to_crs_path(monkeypatch, tmp_path):
+    """Plain dockerfile values continue to resolve under ``crs.crs_path``."""
+    parsed = _render(monkeypatch, tmp_path, "oss-crs/builder.Dockerfile")
+
+    expected = str(tmp_path / "oss-crs/builder.Dockerfile")
+    services = parsed["services"]
+    [(_name, svc)] = list(services.items())
+    assert svc["build"]["dockerfile"] == expected
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    [
+        "oss-crs-infra:default-builder",
+        "oss-crs-infra:builder-sidecar",
+    ],
+)
+def test_infra_prefix_does_not_leak_colon_into_path(monkeypatch, tmp_path, dockerfile):
+    """The literal ``oss-crs-infra:`` token must not appear in the rendered path."""
+    parsed = _render(monkeypatch, tmp_path, dockerfile)
+    services = parsed["services"]
+    [(_name, svc)] = list(services.items())
+    rendered_dockerfile = svc["build"]["dockerfile"]
+
+    assert "oss-crs-infra:" not in rendered_dockerfile
+    assert rendered_dockerfile.endswith("/Dockerfile")


### PR DESCRIPTION
## Summary

`render_build_target_docker_compose` builds the rendered docker-compose
`build.dockerfile` value by joining `build_config.dockerfile` directly under
`crs.crs_path`, skipping the `_resolve_module_dockerfile` helper that other
render paths already use. As a result, framework-infra references such as
`oss-crs-infra:default-builder` get rendered as a literal path
`<crs_path>/oss-crs-infra:default-builder`, and `docker compose` then aborts
with `failed to read dockerfile: open oss-crs-infra:default-builder: no such
file or directory`.

## Reproduction

A CRS that declares an `inc-builder` step with a framework reference, e.g.

```yaml
target_build_phase:
  - name: inc-builder
    snapshot: true
    dockerfile: oss-crs-infra:default-builder
```

triggers the bug when the build-target compose file is rendered for that
build step. Concretely, this is hit by the `crs-claude-code` registry entry
on its `inc-builder` build, and surfaces in CRSBench's smoke tests as:

```
[smoke:bugfixing:worker] failed to solve: failed to read dockerfile:
open oss-crs-infra:default-builder: no such file or directory
[smoke:bugfixing:worker] FAIL Prepare docker images defined in docker compose file
```

## Root cause

`oss_crs/src/templates/renderer.py` already exposes
`_resolve_module_dockerfile(crs_path, dockerfile)` (lines 36–47), which
resolves `oss-crs-infra:<module>` to
`OSS_CRS_ROOT_PATH/oss-crs-infra/<module>/Dockerfile` and falls back to
`crs_path / dockerfile` for plain paths. The `crs_run_phase` rendering path
routes its values through this helper. The build-target context builder
(line 129) was the only call site that bypassed it, so the prefix mechanism
silently failed for any infra reference declared in `target_build_phase`.

This was latent until a CRS started referencing `oss-crs-infra:` from
`target_build_phase`; before that, only `crs_run_phase` exercised the
prefix and the resolver was always applied.

## Fix

Route the build-target context's `builder_dockerfile` through the same
helper:

```python
"builder_dockerfile": _resolve_module_dockerfile(
    crs.crs_path, build_config.dockerfile
),
```

No behavioral change for plain dockerfile paths — `_resolve_module_dockerfile`
falls back to `crs_path / dockerfile` for any value that does not start with
`OSS_CRS_INFRA_PREFIX` (`"oss-crs-infra:"`).

## Tests

Added `oss_crs/tests/unit/test_renderer_build_target.py` with four cases:

- `test_infra_prefix_resolves_to_framework_dockerfile_path` — `oss-crs-infra:default-builder`
  resolves to `OSS_CRS_ROOT_PATH/oss-crs-infra/default-builder/Dockerfile`.
- `test_plain_dockerfile_resolves_relative_to_crs_path` — plain paths still
  resolve to `crs.crs_path / dockerfile`.
- `test_infra_prefix_does_not_leak_colon_into_path` (parametrized) — the
  literal `oss-crs-infra:` token never appears in the rendered dockerfile
  path, and the path ends with `/Dockerfile`.

All four pass; existing `test_renderer_run_compose`, `test_template_rendering`,
and `test_templates` continue to pass unchanged.

## Test plan

- [x] `uv run pytest oss_crs/tests/unit/test_renderer_build_target.py -v`
- [x] `uv run pytest oss_crs/tests/unit/test_renderer_run_compose.py oss_crs/tests/unit/test_template_rendering.py oss_crs/tests/unit/test_templates.py`
- [x] `uv run ruff check oss_crs/tests/unit/test_renderer_build_target.py`
- [x] `uv run ruff format --check oss_crs/tests/unit/test_renderer_build_target.py oss_crs/src/templates/renderer.py`
- [ ] CRSBench-sidecar smoke (`scripts/ci-tests/run-local.sh smoke-bugfixing`) once submodule pointer is bumped to this commit