### PR TITLE
fix: make libcrs install configurable

### DIFF
--- a/docs/design/libCRS.md
+++ b/docs/design/libCRS.md
@@ -16,10 +16,30 @@ COPY libCRS /opt/libCRS
 RUN /opt/libCRS/install.sh
 ```
 
+`install.sh` accepts flags to control what gets installed:
+
+| Flag | Installs |
+|------|----------|
+| *(no flag)* | CLI + Python library (same as `--all`) |
+| `--all` | CLI + Python library |
+| `--cli` | CLI entry point only (`/usr/local/bin/libCRS`) |
+| `--python` | Importable Python library only (`import libcrs`) |
+
+Flags can be combined (e.g., `--cli --python` is equivalent to `--all`).
+
+```bash
+# CLI only (e.g. containers that only shell out to libCRS)
+RUN /opt/libCRS/install.sh --cli
+
+# Python library only (e.g. containers that import libcrs)
+RUN /opt/libCRS/install.sh --python
+```
+
 This installs:
 - [uv](https://github.com/astral-sh/uv) (Python package manager)
 - `rsync` (used for file operations)
-- The `libCRS` CLI tool, available at `/usr/local/bin/libCRS`
+- The `libCRS` CLI tool, available at `/usr/local/bin/libCRS` (when `--cli` or `--all`)
+- The `libcrs` Python package into the system Python (when `--python` or `--all`)
 
 ### Dependencies
 

--- a/libCRS/README.md
+++ b/libCRS/README.md
@@ -9,7 +9,12 @@ COPY --from=libcrs . /opt/libCRS
 RUN /opt/libCRS/install.sh
 ```
 
-This installs the `libCRS` CLI at `/usr/local/bin/libCRS`.
+By default (no flags, or `--all`) this installs both the CLI and the Python library. Use `--cli` or `--python` to install only one:
+
+```dockerfile
+RUN /opt/libCRS/install.sh --cli     # CLI entry point only
+RUN /opt/libCRS/install.sh --python  # importable Python library only
+```
 
 ## Commands
 

--- a/libCRS/install.sh
+++ b/libCRS/install.sh
@@ -4,6 +4,22 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 export DEBIAN_FRONTEND=noninteractive
 
+# Parse install mode (default: --all)
+INSTALL_CLI=false
+INSTALL_PYTHON=false
+if [ $# -eq 0 ]; then
+  INSTALL_CLI=true
+  INSTALL_PYTHON=true
+fi
+for arg in "$@"; do
+  case "$arg" in
+    --all)    INSTALL_CLI=true; INSTALL_PYTHON=true ;;
+    --cli)    INSTALL_CLI=true ;;
+    --python) INSTALL_PYTHON=true ;;
+    *)        echo "Unknown option: $arg (expected --all, --cli, --python)" >&2; exit 1 ;;
+  esac
+done
+
 if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
@@ -18,16 +34,20 @@ export PATH="$HOME/.local/bin:$PATH"
 apt-get update
 apt-get install -y --no-install-recommends rsync
 
-# Install as CLI tool (isolated venv for the entry point)
-uv tool install "$SCRIPT_DIR" --force
+if [ "$INSTALL_CLI" = true ]; then
+  # Install as CLI tool (isolated venv for the entry point)
+  uv tool install "$SCRIPT_DIR" --force
 
-# Also install as importable package for Python API consumers
-uv pip install --system "$SCRIPT_DIR"
+  if [ ! -x "$HOME/.local/bin/libCRS" ]; then
+    echo "libCRS binary missing after uv tool install: $HOME/.local/bin/libCRS" >&2
+    exit 1
+  fi
 
-if [ ! -x "$HOME/.local/bin/libCRS" ]; then
-  echo "libCRS binary missing after uv tool install: $HOME/.local/bin/libCRS" >&2
-  exit 1
+  ln -sf "$HOME/.local/bin/libCRS" /usr/local/bin/libCRS
+  command -v libCRS >/dev/null
 fi
 
-ln -sf "$HOME/.local/bin/libCRS" /usr/local/bin/libCRS
-command -v libCRS >/dev/null
+if [ "$INSTALL_PYTHON" = true ]; then
+  # Install as importable package for Python API consumers
+  uv pip install --system "$SCRIPT_DIR"
+fi


### PR DESCRIPTION
## Summary

Add options to libCRS's install script, so that CRSs may choose whether they want the CLI interface, Python interface, or both (default).

Tested against v1.1.1 of atlantis-multilang-given_fuzzer and atlantis-multilang-wo-concolic.

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [x] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [x] I followed Conventional Commits
- [x] I updated docs for behavior/config/CLI changes
- [ ] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
