### PR TITLE
feat: add patchsense-crs semantic patch validator to registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ stricter subset of Keep a Changelog).
 ## [Unreleased]
 
 ### Added
+- patchsense-crs to registry/ — semantic patch correctness validator; classifies AI-generated patches as root-cause-fix vs. symptom-suppression (96% precision on held-out AIxCC test cases)
 - `--incremental-build` flag for `oss-crs build-target` and `oss-crs run` — creates Docker snapshots of compiled builder images for faster rebuilds across runs
 - Framework-injected builder and runner sidecars during run phase — CRS developers no longer declare them in `crs.yaml`
 - `libCRS apply-patch-test` command — applies a patch and runs the project's `test.sh` in a fresh ephemeral container

--- a/registry/patchsense-crs.yaml
+++ b/registry/patchsense-crs.yaml
@@ -1,0 +1,6 @@
+name: patchsense-crs
+type:
+  - bug-fixing
+source:
+  url: https://github.com/aaronsrhodes/patchsense-crs.git
+  ref: main


### PR DESCRIPTION
## Summary

- Adds `registry/patchsense-crs.yaml` — a semantic patch correctness validator that acts as a post-generation filter in an OSS-CRS ensemble
- Updates `CHANGELOG.md` with the new entry

## What patchsense-crs does

PatchSense addresses the **37–46% semantic error rate** in AI-generated patches that pass functional tests, documented in the AIxCC SoK paper ([arxiv.org/abs/2602.07666](https://arxiv.org/abs/2602.07666)).

It runs as a `bug-fixing` type CRS (no vulnerability discovery — pure validation). It:
1. Fetches patches from the exchange directory
2. Fetches bug-candidate SARIFs to extract CWE and vulnerability context
3. Classifies each patch as **root-cause-fix** or **symptom-suppression** using a fine-tuned Qwen 2.5 Coder 32B model + structural diff analysis
4. Re-submits only confirmed root-cause fixes; discards symptom suppressions
5. Emits a SARIF assessment report for each evaluated patch

## Performance (66 held-out AIxCC test cases)

| Metric | Value |
|--------|:-----:|
| Precision (root-cause-fix) | **96.0%** (24/25) |
| False positive rate | 3.0% (1/33) |
| Recall | 72.7% (24/33) |
| F1 Score | 0.828 |
| Accuracy | 84.8% (56/66) |

Head-to-head: 96.0% precision exceeds every AIxCC finalist team except Shellphish (who achieved 100% via extreme selectivity — submitting only 11/28 found vulns).

## Source repo

https://github.com/aaronsrhodes/patchsense-crs

Includes: `oss-crs/crs.yaml`, Dockerfiles (base/builder/validator), `validator.py`, `sarif_parser.py`, 24 passing tests, example compose config, LiteLLM routing config for local model.

## Supported targets

- Language: `c`, `c++`, `jvm`
- Sanitizer: `address`, `undefined`
- Mode: `full`, `delta`
- Architecture: `x86_64`

## Test plan

- [ ] Verify `registry/patchsense-crs.yaml` schema is valid
- [ ] Confirm source URL is live: https://github.com/aaronsrhodes/patchsense-crs
- [ ] Verify `oss-crs/crs.yaml` in source repo passes schema validation
- [ ] Review `CHANGELOG.md` entry format

🤖 Generated with [Claude Code](https://claude.com/claude-code)