### PR TITLE
chore(crs_compose): increase docker client timeout to 1800s

### DIFF
--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -292,7 +292,7 @@ class CRSCompose:
         Returns:
             True if all snapshots committed successfully, False otherwise (with cleanup).
         """
-        client = docker.from_env(timeout=600)
+        client = docker.from_env(timeout=1800)
         committed_tags: list[str] = []
         target_env = target.get_target_env()
         oss_fuzz_env = {k: target_env[v] for k, v in OSS_FUZZ_TARGET_ENV.items()}


### PR DESCRIPTION
## Summary
- Bump `docker.from_env` timeout from 600s to 1800s in `CRSCompose` snapshot commit flow to accommodate longer-running docker operations.

## Test plan
- [ ] Verify snapshot/commit flow no longer times out on slower hosts.