### PR TITLE
fix: disable patch smoke test on fork and dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
 
   smoke-c-patch:
     name: Smoke test (C patching)
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: [verify]
     timeout-minutes: 40
@@ -273,9 +276,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [verify]
     timeout-minutes: 30
-    env:
-      EXTERNAL_LITELLM_API_BASE: ${{ secrets.EXTERNAL_LITELLM_API_BASE }}
-      EXTERNAL_LITELLM_API_KEY: ${{ secrets.EXTERNAL_LITELLM_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - "libCRS/**"
       - "uv.lock"
       - "pyproject.toml"
+      - ".github/workflows/**"
       - "!**/*.md"
 
 jobs:


### PR DESCRIPTION
## Summary

Disable patch smoke test for dependabot and forks since actions secrets cannot be shared.

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [ ] I followed Conventional Commits
- [ ] I updated docs for behavior/config/CLI changes
- [ ] I added/updated tests for behavior changes
- [ ] I considered backward compatibility and migration impact
