### PR TITLE
chore: bump litellm

### DIFF
--- a/oss_crs/src/constants.py
+++ b/oss_crs/src/constants.py
@@ -1,5 +1,5 @@
 # Container images used by the infrastructure sidecar stack.
-LITELLM_IMAGE = "ghcr.io/berriai/litellm-database@sha256:7c51011535fc9347fc306c8ed7d2e4cdda2336ffd91d930a35fdccd034f2ec17"  # main-stable
+LITELLM_IMAGE = "ghcr.io/berriai/litellm-database@sha256:2dec2d0228b7ad35126e3be5eb8969d8151563dfe5c79a3f25e6ebbd28bf607b"  # main-v1.83.10-stable
 POSTGRES_IMAGE = "postgres@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416"  # 16-alpine
 
 # Internal LiteLLM proxy URL exposed inside the Docker network.


### PR DESCRIPTION
## Summary

Bump LiteLLM to v1.83.10-stable to mitigate https://github.com/BerriAI/litellm/security/advisories/GHSA-r75f-5x8p-qvmc

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [ ] I followed Conventional Commits
- [ ] I updated docs for behavior/config/CLI changes
- [ ] I added/updated tests for behavior changes
- [ ] I considered backward compatibility and migration impact
