### PR TITLE
Add run meta stats to artifacts

### DIFF
--- a/libCRS/libCRS/local.py
+++ b/libCRS/libCRS/local.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import json
 import logging
 import os
 import socket
@@ -17,6 +18,34 @@ logger = logging.getLogger(__name__)
 
 _FUZZ_PROJ_MOUNT = Path("/OSS_CRS_FUZZ_PROJ")
 _TARGET_SOURCE_MOUNT = Path("/OSS_CRS_TARGET_SOURCE")
+
+
+def _append_sidecar_metric(event: str, service: str, exit_code: int) -> None:
+    """Append one sidecar operation event to a JSONL metrics file."""
+    try:
+        log_dir = os.environ.get("OSS_CRS_LOG_DIR")
+        if not log_dir:
+            return
+
+        metrics_file = Path(
+            os.environ.get(
+                "OSS_CRS_SIDECAR_METRICS_FILE",
+                str(Path(log_dir) / "libcrs-sidecar-metrics.jsonl"),
+            )
+        )
+        metrics_file.parent.mkdir(parents=True, exist_ok=True)
+
+        payload = {
+            "ts": int(time.time()),
+            "crs": os.environ.get("OSS_CRS_NAME", "unknown"),
+            "event": event,
+            "service": service,
+            "exit_code": int(exit_code),
+        }
+        with metrics_file.open("a") as f:
+            f.write(json.dumps(payload, sort_keys=True) + "\n")
+    except Exception:
+        return
 
 
 def _get_build_out_dir() -> Path:
@@ -289,6 +318,7 @@ class LocalCRSUtils(CRSUtils):
         if result is None:
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Builder unavailable or timed out")
+            _append_sidecar_metric("apply-patch-build", builder, 1)
             return 1
 
         inner = result.get("result") or {}
@@ -311,6 +341,7 @@ class LocalCRSUtils(CRSUtils):
             (response_dir / "rebuild_id").write_text(str(rid))
             self._last_rebuild_id = rid
 
+        _append_sidecar_metric("apply-patch-build", builder, int(exit_code))
         return exit_code
 
     def run_pov(
@@ -327,6 +358,7 @@ class LocalCRSUtils(CRSUtils):
             response_dir.mkdir(parents=True, exist_ok=True)
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Runner unavailable")
+            _append_sidecar_metric("run-pov", builder, 1)
             return 1
 
         crs_name = os.environ.get("OSS_CRS_NAME", "unknown")
@@ -363,6 +395,7 @@ class LocalCRSUtils(CRSUtils):
             response_dir.mkdir(parents=True, exist_ok=True)
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text(str(e))
+            _append_sidecar_metric("run-pov", builder, 1)
             return 1
 
         response_dir.mkdir(parents=True, exist_ok=True)
@@ -375,6 +408,7 @@ class LocalCRSUtils(CRSUtils):
         if stderr:
             (response_dir / "stderr.log").write_text(stderr)
 
+        _append_sidecar_metric("run-pov", builder, int(exit_code))
         return exit_code
 
     def apply_patch_test(
@@ -401,6 +435,7 @@ class LocalCRSUtils(CRSUtils):
         if result is None:
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Builder unavailable or timed out")
+            _append_sidecar_metric("apply-patch-test", builder, 1)
             return 1
 
         inner = result.get("result") or {}
@@ -418,6 +453,7 @@ class LocalCRSUtils(CRSUtils):
 
         (response_dir / "retcode").write_text(str(exit_code))
 
+        _append_sidecar_metric("apply-patch-test", builder, int(exit_code))
         return exit_code
 
     def download_build_output(

--- a/oss-crs-infra/litellm-key-gen/main.py
+++ b/oss-crs-infra/litellm-key-gen/main.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
+import json
 import os
+import signal
+import time
 import yaml
 import requests
 
@@ -13,6 +16,16 @@ def _read_secret(path: str) -> str:
 
 LITELLM_MASTER_KEY = _read_secret("/run/secrets/litellm_master_key")
 LITELLM_API_URL = os.getenv("LITELLM_API_URL")
+READY_FILE_PATH = os.getenv("LITELLM_KEY_GEN_READY_FILE", "/tmp/litellm-key-gen.ready")
+SPEND_REPORT_PATH = os.getenv("LITELLM_SPEND_REPORT_PATH", "/litellm-spend-report.json")
+SPEND_POLL_INTERVAL_SEC = int(os.getenv("LITELLM_SPEND_POLL_INTERVAL_SEC", "5"))
+
+_SHUTDOWN = False
+
+
+def _handle_signal(_signum, _frame):
+    global _SHUTDOWN
+    _SHUTDOWN = True
 
 
 def create_llm_key(key: str, budget: int) -> str | None:
@@ -71,7 +84,92 @@ def get_available_models() -> list[str]:
         return []
 
 
+def get_global_spend_report() -> dict | list | None:
+    """Fetch global spend report from LiteLLM."""
+    url = f"{LITELLM_API_URL}/global/spend/report"
+    headers = {
+        "Authorization": f"Bearer {LITELLM_MASTER_KEY}",
+    }
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching global spend report: {e}")
+        return None
+
+
+def _iter_dicts(obj):
+    if isinstance(obj, dict):
+        yield obj
+        for v in obj.values():
+            yield from _iter_dicts(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _iter_dicts(item)
+
+
+def _as_float(value) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def summarize_spend_report(report, key_requests: dict[str, dict]) -> dict:
+    """Build a stable summary with totals and per-CRS credits used."""
+    per_key: dict[str, float] = {}
+
+    if report is not None:
+        for entry in _iter_dicts(report):
+            key = None
+            for key_field in ("api_key", "key", "user_api_key", "token"):
+                raw_key = entry.get(key_field)
+                if isinstance(raw_key, str) and raw_key:
+                    key = raw_key
+                    break
+            if key is None:
+                continue
+
+            spend = None
+            for spend_field in ("spend", "total_spend", "credits_used", "cost"):
+                spend = _as_float(entry.get(spend_field))
+                if spend is not None:
+                    break
+            if spend is None:
+                continue
+            per_key[key] = per_key.get(key, 0.0) + spend
+
+    crs_summary: dict[str, dict[str, float]] = {}
+    for crs_name, info in key_requests.items():
+        api_key = str(info.get("api_key", ""))
+        crs_summary[crs_name] = {"credits_used": round(per_key.get(api_key, 0.0), 6)}
+
+    total = round(sum(v["credits_used"] for v in crs_summary.values()), 6)
+    return {
+        "totals": {"credits_used": total},
+        "crs": crs_summary,
+        "updated_at": int(time.time()),
+    }
+
+
+def write_spend_summary(summary: dict) -> None:
+    dst = SPEND_REPORT_PATH
+    tmp = f"{dst}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(summary, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, dst)
+
+
 def main():
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
     yaml_path = "/key_gen_request.yaml"
     with open(yaml_path, "r") as f:
         key_requests = yaml.safe_load(f)
@@ -97,6 +195,19 @@ def main():
         else:
             print(f"Failed to generate API key for CRS '{crs_name}'")
             return 1
+
+    # Mark key generation ready for healthcheck-gated CRS startup.
+    with open(READY_FILE_PATH, "w") as f:
+        f.write("ready\n")
+
+    # Poll LiteLLM spend report and keep writing a host-recoverable summary file.
+    while not _SHUTDOWN:
+        report = get_global_spend_report()
+        summary = summarize_spend_report(report, key_requests)
+        write_spend_summary(summary)
+        time.sleep(max(SPEND_POLL_INTERVAL_SEC, 1))
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/oss-crs-infra/litellm-key-gen/main.py
+++ b/oss-crs-infra/litellm-key-gen/main.py
@@ -84,86 +84,48 @@ def get_available_models() -> list[str]:
         return []
 
 
-def get_global_spend_report() -> dict | list | None:
-    """Fetch global spend report from LiteLLM."""
-    url = f"{LITELLM_API_URL}/global/spend/report"
+def get_key_spend(api_key: str) -> float:
+    """Fetch cumulative spend for a single key via /key/info."""
+    url = f"{LITELLM_API_URL}/key/info"
     headers = {
         "Authorization": f"Bearer {LITELLM_MASTER_KEY}",
     }
     try:
-        response = requests.get(url, headers=headers, timeout=30)
+        response = requests.get(
+            url, headers=headers, params={"key": api_key}, timeout=30
+        )
         response.raise_for_status()
-        return response.json()
+        data = response.json()
+        info = data.get("info") or data
+        spend = info.get("spend")
+        if isinstance(spend, (int, float)):
+            return float(spend)
+        return 0.0
     except requests.exceptions.RequestException as e:
-        print(f"Error fetching global spend report: {e}")
-        return None
+        print(f"Error fetching spend for key: {e}")
+        return 0.0
 
 
-def _iter_dicts(obj):
-    if isinstance(obj, dict):
-        yield obj
-        for v in obj.values():
-            yield from _iter_dicts(v)
-    elif isinstance(obj, list):
-        for item in obj:
-            yield from _iter_dicts(item)
-
-
-def _as_float(value) -> float | None:
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return None
-    return None
-
-
-def summarize_spend_report(report, key_requests: dict[str, dict]) -> dict:
-    """Build a stable summary with totals and per-CRS credits used."""
-    per_key: dict[str, float] = {}
-
-    if report is not None:
-        for entry in _iter_dicts(report):
-            key = None
-            for key_field in ("api_key", "key", "user_api_key", "token"):
-                raw_key = entry.get(key_field)
-                if isinstance(raw_key, str) and raw_key:
-                    key = raw_key
-                    break
-            if key is None:
-                continue
-
-            spend = None
-            for spend_field in ("spend", "total_spend", "credits_used", "cost"):
-                spend = _as_float(entry.get(spend_field))
-                if spend is not None:
-                    break
-            if spend is None:
-                continue
-            per_key[key] = per_key.get(key, 0.0) + spend
-
+def collect_spend_summary(key_requests: dict[str, dict]) -> dict:
+    """Build spend summary by querying per-key spend from LiteLLM."""
     crs_summary: dict[str, dict[str, float]] = {}
+    total = 0.0
     for crs_name, info in key_requests.items():
         api_key = str(info.get("api_key", ""))
-        crs_summary[crs_name] = {"credits_used": round(per_key.get(api_key, 0.0), 6)}
-
-    total = round(sum(v["credits_used"] for v in crs_summary.values()), 6)
+        spend = get_key_spend(api_key) if api_key else 0.0
+        crs_summary[crs_name] = {"credits_used": round(spend, 6)}
+        total += spend
     return {
-        "totals": {"credits_used": total},
+        "totals": {"credits_used": round(total, 6)},
         "crs": crs_summary,
         "updated_at": int(time.time()),
     }
 
 
 def write_spend_summary(summary: dict) -> None:
-    dst = SPEND_REPORT_PATH
-    tmp = f"{dst}.tmp"
-    with open(tmp, "w") as f:
+    with open(SPEND_REPORT_PATH, "w") as f:
         json.dump(summary, f, indent=2, sort_keys=True)
         f.write("\n")
-    os.replace(tmp, dst)
 
 
 def main():
@@ -200,10 +162,9 @@ def main():
     with open(READY_FILE_PATH, "w") as f:
         f.write("ready\n")
 
-    # Poll LiteLLM spend report and keep writing a host-recoverable summary file.
+    # Poll LiteLLM spend and keep writing a host-recoverable summary file.
     while not _SHUTDOWN:
-        report = get_global_spend_report()
-        summary = summarize_spend_report(report, key_requests)
+        summary = collect_spend_summary(key_requests)
         write_spend_summary(summary)
         time.sleep(max(SPEND_POLL_INTERVAL_SEC, 1))
 

--- a/oss_crs/src/cli/artifacts.py
+++ b/oss_crs/src/cli/artifacts.py
@@ -5,7 +5,13 @@ import re
 import sys
 import datetime
 
-from ..config.artifacts import ArtifactsOutput, CRSArtifacts, ExchangeDir, RunLogs
+from ..config.artifacts import (
+    ArtifactsOutput,
+    CRSArtifacts,
+    ExchangeDir,
+    RunLogs,
+    RunMeta,
+)
 from ..target import Target
 from ..utils import normalize_run_id, select
 
@@ -134,6 +140,7 @@ def handle_artifacts(args, crs_compose, target: Target) -> bool:
 
     # Build structured result
     output = ArtifactsOutput(build_id=build_id, run_id=run_id, sanitizer=sanitizer)
+    output.meta = RunMeta.from_work_dir(work_dir, run_id, sanitizer)
 
     if harness:
         output.exchange_dir = ExchangeDir.from_work_dir(

--- a/oss_crs/src/config/artifacts.py
+++ b/oss_crs/src/config/artifacts.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import json
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -60,6 +61,39 @@ class RunLogs(BaseModel):
             compose_stderr_log=str(base_path / "docker-compose.stderr.log"),
             service_logs=str(base_path / "services"),
         )
+
+
+class RunMeta(BaseModel):
+    """Run-level statistics from run metadata."""
+
+    path: Optional[str] = None
+    llm_credits_used: Optional[float] = None
+    povs_found: Optional[int] = None
+    seeds_shared: Optional[int] = None
+    builds_requested: Optional[int] = None
+
+    @classmethod
+    def from_work_dir(
+        cls,
+        work_dir: WorkDir,
+        run_id: str,
+        sanitizer: str,
+    ) -> "RunMeta":
+        meta_path = work_dir.get_run_meta_file(run_id, sanitizer)
+        out = cls(path=str(meta_path))
+        if not meta_path.exists():
+            return out
+        try:
+            raw = json.loads(meta_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return out
+        if not isinstance(raw, dict):
+            return out
+        out.llm_credits_used = raw.get("llm_credits_used")
+        out.povs_found = raw.get("povs_found")
+        out.seeds_shared = raw.get("seeds_shared")
+        out.builds_requested = raw.get("builds_requested")
+        return out
 
 
 class CRSArtifacts(BaseModel):
@@ -128,6 +162,7 @@ class ArtifactsOutput(BaseModel):
     build_id: Optional[str] = None
     run_id: str
     sanitizer: Optional[str] = None
+    meta: Optional[RunMeta] = None
     exchange_dir: Optional[ExchangeDir] = None
     run_logs: Optional[RunLogs] = None
     crs: dict[str, CRSArtifacts] = Field(default_factory=dict)

--- a/oss_crs/src/config/artifacts.py
+++ b/oss_crs/src/config/artifacts.py
@@ -63,14 +63,41 @@ class RunLogs(BaseModel):
         )
 
 
+class MetaArtifactCounts(BaseModel):
+    povs: int = 0
+    seeds: int = 0
+    patches: int = 0
+    bug_candidates: int = 0
+
+
+class MetaLLMStats(BaseModel):
+    credits_used: float = 0.0
+
+
+class MetaSidecarStats(BaseModel):
+    patch_builds: int = 0
+    patch_tests: int = 0
+    pov_runs: int = 0
+
+
+class MetaCRSStats(BaseModel):
+    artifacts: MetaArtifactCounts = Field(default_factory=MetaArtifactCounts)
+    llm: MetaLLMStats = Field(default_factory=MetaLLMStats)
+    sidecar: MetaSidecarStats = Field(default_factory=MetaSidecarStats)
+
+
+class MetaTotals(BaseModel):
+    artifacts: MetaArtifactCounts = Field(default_factory=MetaArtifactCounts)
+    llm: MetaLLMStats = Field(default_factory=MetaLLMStats)
+    sidecar: MetaSidecarStats = Field(default_factory=MetaSidecarStats)
+
+
 class RunMeta(BaseModel):
     """Run-level statistics from run metadata."""
 
     path: Optional[str] = None
-    llm_credits_used: Optional[float] = None
-    povs_found: Optional[int] = None
-    seeds_shared: Optional[int] = None
-    builds_requested: Optional[int] = None
+    totals: MetaTotals = Field(default_factory=MetaTotals)
+    crs: dict[str, MetaCRSStats] = Field(default_factory=dict)
 
     @classmethod
     def from_work_dir(
@@ -89,10 +116,13 @@ class RunMeta(BaseModel):
             return out
         if not isinstance(raw, dict):
             return out
-        out.llm_credits_used = raw.get("llm_credits_used")
-        out.povs_found = raw.get("povs_found")
-        out.seeds_shared = raw.get("seeds_shared")
-        out.builds_requested = raw.get("builds_requested")
+        out.totals = MetaTotals.model_validate(raw.get("totals") or {})
+        crs_raw = raw.get("crs")
+        if isinstance(crs_raw, dict):
+            out.crs = {
+                str(name): MetaCRSStats.model_validate(stats or {})
+                for name, stats in crs_raw.items()
+            }
         return out
 
 

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
-import shutil
-import subprocess
-import re
+import hashlib
 import json
 import os
-import hashlib
+import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional
 from .config.crs_compose import CRSComposeConfig, CRSComposeEnv, RunEnv
@@ -38,6 +38,12 @@ import requests.exceptions
 
 
 class CRSCompose:
+    _LITELLM_COST_PATTERNS = (
+        re.compile(r'"response_cost"\s*:\s*([0-9]+(?:\.[0-9]+)?)'),
+        re.compile(r"response_cost\s*=\s*([0-9]+(?:\.[0-9]+)?)"),
+    )
+    _LIBCRS_BUILD_REQUEST_PATTERN = re.compile(r"apply-patch-build")
+
     @classmethod
     def from_yaml_file(
         cls, compose_file: Path, work_dir: Path, skip_crs_init: bool = False
@@ -1138,6 +1144,8 @@ class CRSCompose:
                     if not success:
                         log_dim(f"Note: Cgroup cleanup deferred: {msg}")
 
+                self._write_run_meta(target, actual_run_id, sanitizer)
+
                 if ret.success or ret.interrupted:
                     self.__show_result_local(target, actual_run_id, sanitizer, progress)
                     if ret.success:
@@ -1318,6 +1326,75 @@ class CRSCompose:
                 dst.symlink_to(rel_src)
             except OSError:
                 shutil.copy2(src, dst)
+
+    @staticmethod
+    def _count_files(path: Path) -> int:
+        if not path.exists() or not path.is_dir():
+            return 0
+        return sum(1 for p in path.iterdir() if p.is_file())
+
+    def _sum_llm_credits_from_service_logs(self, services_dir: Path) -> float:
+        if not services_dir.exists() or not services_dir.is_dir():
+            return 0.0
+        total = 0.0
+        for log_path in services_dir.glob("*.log"):
+            try:
+                content = log_path.read_text(errors="ignore")
+            except OSError:
+                continue
+            for pattern in self._LITELLM_COST_PATTERNS:
+                for match in pattern.finditer(content):
+                    try:
+                        total += float(match.group(1))
+                    except (TypeError, ValueError):
+                        continue
+        return round(total, 6)
+
+    def _count_build_requests_from_service_logs(self, services_dir: Path) -> int:
+        if not services_dir.exists() or not services_dir.is_dir():
+            return 0
+        count = 0
+        for log_path in services_dir.glob("*.log"):
+            try:
+                content = log_path.read_text(errors="ignore")
+            except OSError:
+                continue
+            count += len(self._LIBCRS_BUILD_REQUEST_PATTERN.findall(content))
+        return count
+
+    def _collect_run_meta(self, target: Target, run_id: str, sanitizer: str) -> dict:
+        povs_found = 0
+        seeds_shared = 0
+        for crs in self.crs_list:
+            submit_dir = self.work_dir.get_submit_dir(
+                crs.name, target, run_id, sanitizer, create=False
+            )
+            povs_found += self._count_files(submit_dir / "povs")
+            seeds_shared += self._count_files(submit_dir / "seeds")
+
+        run_logs_dir = self.work_dir.get_run_logs_dir(
+            target, run_id, sanitizer, create=False
+        )
+        services_dir = run_logs_dir / "services"
+
+        return {
+            "llm_credits_used": self._sum_llm_credits_from_service_logs(services_dir),
+            "povs_found": povs_found,
+            "seeds_shared": seeds_shared,
+            "builds_requested": self._count_build_requests_from_service_logs(
+                services_dir
+            ),
+        }
+
+    def _write_run_meta(self, target: Target, run_id: str, sanitizer: str) -> None:
+        try:
+            metadata = self._collect_run_meta(target, run_id, sanitizer)
+            self.work_dir.write_run_meta_for_run(run_id, sanitizer, metadata)
+        except Exception as exc:
+            log_dim(
+                "Note: Failed to write run metadata "
+                f"for run '{run_id}': {type(exc).__name__}: {exc}"
+            )
 
     def __show_result_local(
         self, target: Target, run_id: str, sanitizer: str, progress: MultiTaskProgress

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -38,12 +38,6 @@ import requests.exceptions
 
 
 class CRSCompose:
-    _LITELLM_COST_PATTERNS = (
-        re.compile(r'"response_cost"\s*:\s*([0-9]+(?:\.[0-9]+)?)'),
-        re.compile(r"response_cost\s*=\s*([0-9]+(?:\.[0-9]+)?)"),
-    )
-    _LIBCRS_BUILD_REQUEST_PATTERN = re.compile(r"apply-patch-build")
-
     @classmethod
     def from_yaml_file(
         cls, compose_file: Path, work_dir: Path, skip_crs_init: bool = False
@@ -1328,62 +1322,121 @@ class CRSCompose:
                 shutil.copy2(src, dst)
 
     @staticmethod
-    def _count_files(path: Path) -> int:
-        if not path.exists() or not path.is_dir():
-            return 0
-        return sum(1 for p in path.iterdir() if p.is_file())
+    def _read_json_file(path: Path) -> dict:
+        try:
+            raw = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return raw if isinstance(raw, dict) else {}
 
-    def _sum_llm_credits_from_service_logs(self, services_dir: Path) -> float:
-        if not services_dir.exists() or not services_dir.is_dir():
-            return 0.0
-        total = 0.0
-        for log_path in services_dir.glob("*.log"):
-            try:
-                content = log_path.read_text(errors="ignore")
-            except OSError:
-                continue
-            for pattern in self._LITELLM_COST_PATTERNS:
-                for match in pattern.finditer(content):
-                    try:
-                        total += float(match.group(1))
-                    except (TypeError, ValueError):
-                        continue
-        return round(total, 6)
+    def _read_litellm_spend_summary(self, run_id: str, sanitizer: str) -> dict:
+        path = self.work_dir.get_litellm_spend_report_file(
+            run_id, sanitizer, create_parent=False
+        )
+        raw = self._read_json_file(path)
+        totals_raw = raw.get("totals")
+        totals = totals_raw if isinstance(totals_raw, dict) else {}
+        crs_raw = raw.get("crs")
+        crs = crs_raw if isinstance(crs_raw, dict) else {}
+        return {
+            "totals": {"credits_used": float(totals.get("credits_used", 0.0) or 0.0)},
+            "crs": {
+                name: {"credits_used": float((entry or {}).get("credits_used", 0.0))}
+                for name, entry in crs.items()
+                if isinstance(name, str)
+            },
+        }
 
-    def _count_build_requests_from_service_logs(self, services_dir: Path) -> int:
-        if not services_dir.exists() or not services_dir.is_dir():
-            return 0
-        count = 0
-        for log_path in services_dir.glob("*.log"):
-            try:
-                content = log_path.read_text(errors="ignore")
-            except OSError:
-                continue
-            count += len(self._LIBCRS_BUILD_REQUEST_PATTERN.findall(content))
-        return count
+    def _read_sidecar_counts_for_crs(
+        self, crs_name: str, target: Target, run_id: str, sanitizer: str
+    ) -> dict[str, int]:
+        path = self.work_dir.get_sidecar_metrics_file(
+            crs_name, target, run_id, sanitizer
+        )
+        counts = {
+            "patch_builds": 0,
+            "patch_tests": 0,
+            "pov_runs": 0,
+        }
+        if not path.exists() or not path.is_file():
+            return counts
+
+        event_to_field = {
+            "apply-patch-build": "patch_builds",
+            "apply-patch-test": "patch_tests",
+            "run-pov": "pov_runs",
+        }
+        try:
+            for line in path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                event = row.get("event")
+                field = event_to_field.get(event)
+                if field:
+                    counts[field] += 1
+        except OSError:
+            return counts
+        return counts
 
     def _collect_run_meta(self, target: Target, run_id: str, sanitizer: str) -> dict:
-        povs_found = 0
-        seeds_shared = 0
-        for crs in self.crs_list:
-            submit_dir = self.work_dir.get_submit_dir(
-                crs.name, target, run_id, sanitizer, create=False
-            )
-            povs_found += self._count_files(submit_dir / "povs")
-            seeds_shared += self._count_files(submit_dir / "seeds")
+        llm_summary = self._read_litellm_spend_summary(run_id, sanitizer)
 
-        run_logs_dir = self.work_dir.get_run_logs_dir(
-            target, run_id, sanitizer, create=False
-        )
-        services_dir = run_logs_dir / "services"
+        totals = {
+            "artifacts": {
+                "povs": 0,
+                "seeds": 0,
+                "patches": 0,
+                "bug_candidates": 0,
+            },
+            "llm": {"credits_used": 0.0},
+            "sidecar": {
+                "patch_builds": 0,
+                "patch_tests": 0,
+                "pov_runs": 0,
+            },
+        }
+        crs_meta: dict[str, dict] = {}
+
+        for crs in self.crs_list:
+            artifacts = self.work_dir.get_submit_artifact_counts(
+                crs.name, target, run_id, sanitizer
+            )
+            sidecar = self._read_sidecar_counts_for_crs(
+                crs.name, target, run_id, sanitizer
+            )
+            llm = {
+                "credits_used": float(
+                    llm_summary.get("crs", {})
+                    .get(crs.name, {})
+                    .get("credits_used", 0.0)
+                )
+            }
+
+            crs_meta[crs.name] = {
+                "artifacts": artifacts,
+                "llm": llm,
+                "sidecar": sidecar,
+            }
+
+            for key in totals["artifacts"]:
+                totals["artifacts"][key] += artifacts.get(key, 0)
+            for key in totals["sidecar"]:
+                totals["sidecar"][key] += sidecar.get(key, 0)
+
+        llm_total = float(llm_summary.get("totals", {}).get("credits_used", 0.0))
+        if llm_total == 0.0:
+            llm_total = round(
+                sum(crs_meta[name]["llm"]["credits_used"] for name in crs_meta), 6
+            )
+        totals["llm"]["credits_used"] = llm_total
 
         return {
-            "llm_credits_used": self._sum_llm_credits_from_service_logs(services_dir),
-            "povs_found": povs_found,
-            "seeds_shared": seeds_shared,
-            "builds_requested": self._count_build_requests_from_service_logs(
-                services_dir
-            ),
+            "totals": totals,
+            "crs": crs_meta,
         }
 
     def _write_run_meta(self, target: Target, run_id: str, sanitizer: str) -> None:

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -301,6 +301,14 @@ def render_run_crs_compose_docker_compose(
     )
 
     target_env = target.get_target_env()
+    if hasattr(crs_compose.work_dir, "get_litellm_spend_report_file"):
+        litellm_spend_report_path = str(
+            crs_compose.work_dir.get_litellm_spend_report_file(run_id, sanitizer)
+        )
+    else:
+        tmp_dir = tmp_docker_compose.dir if tmp_docker_compose.dir else Path("/tmp")
+        litellm_spend_report_path = str(tmp_dir / "litellm-spend-report.json")
+
     context = {
         "libCRS_path": str(LIBCRS_PATH),
         "crs_compose_name": crs_compose_name,
@@ -330,9 +338,7 @@ def render_run_crs_compose_docker_compose(
         ),
         "litellm_image": LITELLM_IMAGE,
         "litellm_internal_url": LITELLM_INTERNAL_URL,
-        "litellm_spend_report_path": str(
-            crs_compose.work_dir.get_litellm_spend_report_file(run_id, sanitizer)
-        ),
+        "litellm_spend_report_path": litellm_spend_report_path,
         "postgres_image": POSTGRES_IMAGE,
         "postgres_user": POSTGRES_USER,
         "postgres_port": POSTGRES_PORT,

--- a/oss_crs/src/templates/renderer.py
+++ b/oss_crs/src/templates/renderer.py
@@ -330,6 +330,9 @@ def render_run_crs_compose_docker_compose(
         ),
         "litellm_image": LITELLM_IMAGE,
         "litellm_internal_url": LITELLM_INTERNAL_URL,
+        "litellm_spend_report_path": str(
+            crs_compose.work_dir.get_litellm_spend_report_file(run_id, sanitizer)
+        ),
         "postgres_image": POSTGRES_IMAGE,
         "postgres_user": POSTGRES_USER,
         "postgres_port": POSTGRES_PORT,

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -38,7 +38,7 @@ services:
 {%- if llm_context is defined and llm_context.mode == "internal" %}
     depends_on:
       oss-crs-litellm-key-gen:
-        condition: service_completed_successfully
+  condition: service_healthy
 {%- endif %}
 {%- if llm_context is defined and crs.name in llm_context.secret_files %}
     secrets:
@@ -149,12 +149,21 @@ services:
         condition: service_healthy
     environment:
       - LITELLM_API_URL={{ litellm_internal_url }}
+      - LITELLM_SPEND_REPORT_PATH=/litellm-spend-report.json
+      - LITELLM_SPEND_POLL_INTERVAL_SEC=5
     secrets:
       - litellm_master_key
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /tmp/litellm-key-gen.ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
     networks:
       {{ crs_compose_name }}-network:
     volumes:
       - {{ llm_context.key_gen_request_path }}:/key_gen_request.yaml:ro
+      - {{ litellm_spend_report_path }}:/litellm-spend-report.json:rw
   ###########################################
 {% endif %}
   ###########################################

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -38,7 +38,7 @@ services:
 {%- if llm_context is defined and llm_context.mode == "internal" %}
     depends_on:
       oss-crs-litellm-key-gen:
-  condition: service_healthy
+        condition: service_healthy
 {%- endif %}
 {%- if llm_context is defined and crs.name in llm_context.secret_files %}
     secrets:

--- a/oss_crs/src/ui.py
+++ b/oss_crs/src/ui.py
@@ -1315,8 +1315,6 @@ class MultiTaskProgress:
 
 def _count_files(dir_path: Path) -> int:
     """Count non-hidden files in a directory."""
-    if not dir_path.exists():
-        return 0
-    return len(
-        [f for f in dir_path.iterdir() if f.is_file() and not f.name.startswith(".")]
-    )
+    from .workdir import WorkDir
+
+    return WorkDir.count_data_files(dir_path)

--- a/oss_crs/src/workdir.py
+++ b/oss_crs/src/workdir.py
@@ -20,6 +20,7 @@ logic for the CRS Compose work directory structure:
                     └── LOG_DIR/<harness>/
 """
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -463,6 +464,10 @@ class WorkDir:
         """Get the BUILD_ID file path for a run."""
         return self.get_run_dir(run_id, sanitizer) / "BUILD_ID"
 
+    def get_run_meta_file(self, run_id: str, sanitizer: str) -> Path:
+        """Get the run metadata file path for a run."""
+        return self.get_run_dir(run_id, sanitizer) / "meta.json"
+
     def read_build_id_for_run(self, run_id: str, sanitizer: str) -> str | None:
         """Read the build-id that was used for a specific run."""
         build_id_file = self.get_build_id_file(run_id, sanitizer)
@@ -477,3 +482,13 @@ class WorkDir:
         run_dir = self.get_run_dir(run_id, sanitizer)
         run_dir.mkdir(parents=True, exist_ok=True)
         self.get_build_id_file(run_id, sanitizer).write_text(build_id)
+
+    def write_run_meta_for_run(
+        self, run_id: str, sanitizer: str, metadata: dict
+    ) -> None:
+        """Write run metadata to meta.json for a specific run."""
+        run_dir = self.get_run_dir(run_id, sanitizer)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        self.get_run_meta_file(run_id, sanitizer).write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+        )

--- a/oss_crs/src/workdir.py
+++ b/oss_crs/src/workdir.py
@@ -64,6 +64,19 @@ class WorkDir:
         """Compute target_key from a Target."""
         return target.get_docker_image_name().replace(":", "_")
 
+    @staticmethod
+    def count_data_files(dir_path: Path) -> int:
+        """Count non-hidden files in a directory."""
+        if not dir_path.exists() or not dir_path.is_dir():
+            return 0
+        return len(
+            [
+                f
+                for f in dir_path.iterdir()
+                if f.is_file() and not f.name.startswith(".")
+            ]
+        )
+
     # -------------------------------------------------------------------------
     # Base directory helpers
     # -------------------------------------------------------------------------
@@ -467,6 +480,49 @@ class WorkDir:
     def get_run_meta_file(self, run_id: str, sanitizer: str) -> Path:
         """Get the run metadata file path for a run."""
         return self.get_run_dir(run_id, sanitizer) / "meta.json"
+
+    def get_litellm_spend_report_file(
+        self, run_id: str, sanitizer: str, create_parent: bool = True
+    ) -> Path:
+        """Get run-level LiteLLM spend report file path."""
+        run_dir = self.get_run_dir(run_id, sanitizer)
+        if create_parent:
+            run_dir.mkdir(parents=True, exist_ok=True)
+        path = run_dir / "litellm-spend-report.json"
+        if create_parent:
+            path.touch(exist_ok=True)
+        return path
+
+    def get_sidecar_metrics_file(
+        self,
+        crs_name: str,
+        target: Target,
+        run_id: str,
+        sanitizer: str,
+    ) -> Path:
+        """Get per-CRS sidecar metrics file path under LOG_DIR."""
+        return (
+            self.get_log_dir(crs_name, target, run_id, sanitizer, create=False)
+            / "libcrs-sidecar-metrics.jsonl"
+        )
+
+    def get_submit_artifact_counts(
+        self,
+        crs_name: str,
+        target: Target,
+        run_id: str,
+        sanitizer: str,
+    ) -> dict[str, int]:
+        """Count run artifacts for one CRS from SUBMIT_DIR."""
+        submit_dir = self.get_submit_dir(
+            crs_name, target, run_id, sanitizer, create=False
+        )
+        return {
+            "povs": self.count_data_files(submit_dir / "povs"),
+            "seeds": self.count_data_files(submit_dir / "seeds"),
+            "patches": self.count_data_files(submit_dir / "patches"),
+            "bug_candidates": self.count_data_files(submit_dir / "bug-candidates"),
+        }
 
     def read_build_id_for_run(self, run_id: str, sanitizer: str) -> str | None:
         """Read the build-id that was used for a specific run."""

--- a/oss_crs/tests/unit/test_cli_artifacts_prerun.py
+++ b/oss_crs/tests/unit/test_cli_artifacts_prerun.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for artifacts command pre-run path resolution behavior."""
 
+import json
 from types import SimpleNamespace
 
 from oss_crs.src.cli.artifacts import handle_artifacts
@@ -28,6 +29,9 @@ class _FakeWorkDir:
 
     def read_build_id_for_run(self, _run_id: str, _sanitizer: str) -> str | None:
         return None
+
+    def get_run_meta_file(self, run_id: str, sanitizer: str):
+        return self._tmp / sanitizer / "runs" / run_id / "meta.json"
 
     def get_exchange_dir(
         self, target, run_id: str, sanitizer: str, *, create: bool = False
@@ -206,3 +210,34 @@ def test_artifacts_resolves_default_sanitizer_from_compose(tmp_path, capsys) -> 
 
     out = capsys.readouterr().out
     assert '"sanitizer": "memory"' in out
+
+
+def test_artifacts_includes_meta_stats_when_meta_json_exists(tmp_path, capsys) -> None:
+    run_id = "existing-run-id"
+    sanitizer = "address"
+    meta_path = tmp_path / sanitizer / "runs" / run_id / "meta.json"
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(
+        json.dumps(
+            {
+                "llm_credits_used": 1.25,
+                "povs_found": 2,
+                "seeds_shared": 3,
+                "builds_requested": 4,
+            }
+        )
+    )
+
+    compose = _make_compose(tmp_path, resolved_run_id=run_id)
+    args = _make_args(run_id, sanitizer=sanitizer)
+    target = _FakeTarget("fuzz_target")
+
+    ok = handle_artifacts(args, compose, target)
+    assert ok is True
+
+    out = capsys.readouterr().out
+    assert '"meta"' in out
+    assert '"llm_credits_used": 1.25' in out
+    assert '"povs_found": 2' in out
+    assert '"seeds_shared": 3' in out
+    assert '"builds_requested": 4' in out

--- a/oss_crs/tests/unit/test_cli_artifacts_prerun.py
+++ b/oss_crs/tests/unit/test_cli_artifacts_prerun.py
@@ -220,10 +220,36 @@ def test_artifacts_includes_meta_stats_when_meta_json_exists(tmp_path, capsys) -
     meta_path.write_text(
         json.dumps(
             {
-                "llm_credits_used": 1.25,
-                "povs_found": 2,
-                "seeds_shared": 3,
-                "builds_requested": 4,
+                "totals": {
+                    "artifacts": {
+                        "povs": 2,
+                        "seeds": 4,
+                        "patches": 1,
+                        "bug_candidates": 2,
+                    },
+                    "llm": {"credits_used": 1.65},
+                    "sidecar": {
+                        "patch_builds": 4,
+                        "patch_tests": 2,
+                        "pov_runs": 8,
+                    },
+                },
+                "crs": {
+                    "crs-a": {
+                        "artifacts": {
+                            "povs": 2,
+                            "seeds": 3,
+                            "patches": 1,
+                            "bug_candidates": 0,
+                        },
+                        "llm": {"credits_used": 1.25},
+                        "sidecar": {
+                            "patch_builds": 4,
+                            "patch_tests": 2,
+                            "pov_runs": 7,
+                        },
+                    }
+                },
             }
         )
     )
@@ -237,7 +263,9 @@ def test_artifacts_includes_meta_stats_when_meta_json_exists(tmp_path, capsys) -
 
     out = capsys.readouterr().out
     assert '"meta"' in out
-    assert '"llm_credits_used": 1.25' in out
-    assert '"povs_found": 2' in out
-    assert '"seeds_shared": 3' in out
-    assert '"builds_requested": 4' in out
+    assert '"totals"' in out
+    assert '"credits_used": 1.65' in out
+    assert '"patch_builds": 4' in out
+    assert '"patch_tests": 2' in out
+    assert '"pov_runs": 8' in out
+    assert '"bug_candidates": 2' in out


### PR DESCRIPTION
## Summary

Added run-level statistics capture and persistence so each run writes a meta.json under its run directory, then exposed that metadata through the artifacts command output.

This was done to satisfy the issue requirement to track and retrieve:
- LLM credits used
- POVs found
- Seeds shared
- Number of builds requested through libCRS

## User Impact

- [x] User-facing change
- [ ] Internal-only change

CLI/API/config/docs impact and migration:
- CLI output change: artifacts JSON now includes a top-level meta object when resolving a run.
- No new required flags and no command rename/removal.
- Existing consumers that ignore unknown JSON fields continue to work.
- Consumers with strict JSON schema validation should allow the new optional meta field.

## Release Note / Changelog

- [ ] I updated CHANGELOG.md ([Unreleased]) for user-facing changes
- [x] No changelog entry needed (internal-only refactor/test/chore)

Deprecation or breaking behavior:
- None.
- No replacement path needed.
- No planned removal window.

## Validation

- Added/updated unit test coverage for artifacts meta output behavior.
- Ran static diagnostics on changed files with no reported errors.
- Attempted targeted pytest run for the updated artifacts test module, but local execution in this Windows environment is blocked during collection by a Linux-only fcntl import dependency.

## Checklist

- [ ] I followed Conventional Commits
- [ ] I updated docs for behavior/config/CLI changes
- [x] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact

Closes #80 