### PR TITLE
Better artifact retrieval after campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ stricter subset of Keep a Changelog).
 ## [Unreleased]
 
 ### Added
+- `oss-crs archive` command — packages submitted artifacts (POVs, seeds, patches, bug-candidates) from a run into a `.tar.gz`. When a triage CRS is present, POVs are sourced from its submit dir instead of individual CRS submit dirs. Use `--all` to also include exchange dir, logs, and shared dirs. Supports `--run-id`, `--latest`, and `--sanitizer` for run selection.
+- `--latest` flag for `oss-crs artifacts` and `oss-crs archive` — automatically selects the most recent run instead of prompting interactively.
 - `oss-crs gen-compose --litellm-proxy KEY_ENV PROVIDERS [BASE_URL_ENV]` — override litellm config env vars to route selected providers through a proxy. Only rewrites entries that use known default provider keys; custom keys (e.g. `VLLM_KEY`) are never touched.
 - `oss-crs setup` now includes an interactive LLM proxy configuration phase — asks which providers to route through a proxy, the key/base-URL env var names, and applies the override to all example litellm configs that use default provider keys.
 - `LITELLM_PROVIDERS` constant in `llm.py` — canonical registry mapping provider names to model prefixes and default API key env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`).
@@ -31,6 +33,8 @@ stricter subset of Keep a Changelog).
 - `libCRS download-source target-source <dest>`: copies clean target source
 
 ### Changed
+- Post-run results are now printed outside the Rich UI box so long artifact directory paths are never truncated by panel border wrapping. Directories are only shown when the artifact count is non-zero.
+- `oss-crs artifacts` and `oss-crs archive` now ignore unrecognized CLI arguments, allowing run command args to be forwarded directly.
 - Example litellm configs now use standard provider API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`) by default instead of `EXTERNAL_LITELLM_API_KEY`/`EXTERNAL_LITELLM_API_BASE`. Use `oss-crs setup` or `gen-compose --litellm-proxy` to configure proxy routing.
 - `oss-crs setup` is now a general setup command (LLM configuration + cgroup setup) instead of cgroup-only.
 - Builder sidecar redesigned: framework-injected ephemeral containers replace CRS-declared long-running builders. Rebuilds launch a fresh container per patch from the preserved builder image.

--- a/oss_crs/src/cli/archive.py
+++ b/oss_crs/src/cli/archive.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+"""Archive command: package submitted artifacts from a run into a tarball."""
+
+import sys
+import tarfile
+from pathlib import Path
+
+from .artifacts import resolve_run_context
+from ..target import Target
+
+
+def handle_archive(args, crs_compose, target: Target) -> bool:
+    """Handle the archive command."""
+    ctx = resolve_run_context(args, crs_compose, target)
+    if ctx is None:
+        return False
+    sanitizer, run_id = ctx
+    harness = target.target_harness
+    work_dir = crs_compose.work_dir
+
+    out_path = Path(args.out)
+
+    # Identify triage CRS(s)
+    triage_crs = [crs for crs in crs_compose.crs_list if crs.config.is_triage]
+    non_triage_crs = [crs for crs in crs_compose.crs_list if not crs.config.is_triage]
+
+    # Collect (arcname, src_path) pairs for each artifact subdir
+    artifact_subdirs = ["povs", "seeds", "patches", "bug-candidates"]
+
+    def _add_dir(collected: list, src_dir: Path, arcname_prefix: str) -> None:
+        """Recursively add files from src_dir under arcname_prefix."""
+        if not src_dir.exists():
+            return
+        for f in src_dir.rglob("*"):
+            if f.is_file():
+                rel = f.relative_to(src_dir)
+                collected.append((f, f"{arcname_prefix}/{rel}"))
+
+    collected: list[tuple[Path, str]] = []
+
+    if triage_crs:
+        # POVs come from the triage CRS submit dir (verified/dedup'd)
+        for crs in triage_crs:
+            submit_dir = work_dir.get_submit_dir(
+                crs.name, target, run_id, sanitizer, create=False
+            )
+            _add_dir(collected, submit_dir / "povs", "povs")
+
+        # Seeds, patches, bug-candidates from non-triage CRSs
+        for crs in non_triage_crs:
+            submit_dir = work_dir.get_submit_dir(
+                crs.name, target, run_id, sanitizer, create=False
+            )
+            for subdir in ["seeds", "patches", "bug-candidates"]:
+                _add_dir(collected, submit_dir / subdir, subdir)
+    else:
+        # No triage: collect all submitted artifact types from every CRS
+        for crs in crs_compose.crs_list:
+            submit_dir = work_dir.get_submit_dir(
+                crs.name, target, run_id, sanitizer, create=False
+            )
+            for subdir in artifact_subdirs:
+                _add_dir(collected, submit_dir / subdir, subdir)
+
+    if args.include_all:
+        # Also include exchange dir, logs, shared dirs, and build output
+        if harness:
+            exchange_dir = work_dir.get_exchange_dir(
+                target, run_id, sanitizer, create=False
+            )
+            _add_dir(collected, exchange_dir, "exchange")
+
+            run_logs_dir = work_dir.get_run_logs_dir(
+                target, run_id, sanitizer, create=False
+            )
+            _add_dir(collected, run_logs_dir, "logs")
+
+            for crs in crs_compose.crs_list:
+                shared_dir = work_dir.get_shared_dir(
+                    crs.name, target, run_id, sanitizer, create=False
+                )
+                _add_dir(collected, shared_dir, f"shared/{crs.name}")
+
+                log_dir = work_dir.get_log_dir(
+                    crs.name, target, run_id, sanitizer, create=False
+                )
+                _add_dir(collected, log_dir, f"logs/crs/{crs.name}")
+
+    if not collected:
+        print("No artifacts found for the selected run.", file=sys.stderr)
+        return False
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(out_path, "w:gz") as tar:
+        seen_arcnames: set[str] = set()
+        for src, arcname in collected:
+            # Deduplicate: if multiple CRSs produced the same filename, suffix with index
+            base_arcname = arcname
+            idx = 1
+            while arcname in seen_arcnames:
+                stem = Path(base_arcname)
+                arcname = str(stem.parent / f"{stem.stem}.{idx}{stem.suffix}")
+                idx += 1
+            seen_arcnames.add(arcname)
+            tar.add(src, arcname=arcname)
+
+    total = len(seen_arcnames)
+    print(f"Archived {total} file(s) to {out_path}")
+    return True

--- a/oss_crs/src/cli/archive.py
+++ b/oss_crs/src/cli/archive.py
@@ -70,7 +70,7 @@ def handle_archive(args, crs_compose, target: Target) -> bool:
                 _add_dir(collected, submit_dir / subdir, subdir)
 
     if args.include_all:
-        # Also include exchange dir, logs, shared dirs, and build output
+        # Also include exchange dir, logs, and shared dirs
         if harness:
             exchange_dir = work_dir.get_exchange_dir(
                 target, run_id, sanitizer, create=False

--- a/oss_crs/src/cli/archive.py
+++ b/oss_crs/src/cli/archive.py
@@ -31,10 +31,17 @@ def handle_archive(args, crs_compose, target: Target) -> bool:
         """Recursively add files from src_dir under arcname_prefix."""
         if not src_dir.exists():
             return
+
+        resolved_src_dir = src_dir.resolve()
         for f in src_dir.rglob("*"):
-            if f.is_file():
-                rel = f.relative_to(src_dir)
-                collected.append((f, f"{arcname_prefix}/{rel}"))
+            if f.is_symlink() or not f.is_file():
+                continue
+            try:
+                f.resolve().relative_to(resolved_src_dir)
+            except ValueError:
+                continue
+            rel = f.relative_to(src_dir)
+            collected.append((f, f"{arcname_prefix}/{rel}"))
 
     collected: list[tuple[Path, str]] = []
 

--- a/oss_crs/src/cli/artifacts.py
+++ b/oss_crs/src/cli/artifacts.py
@@ -66,18 +66,21 @@ def select_run_id_interactively(
     return select("Select run-id:", choices)
 
 
-def handle_artifacts(args, crs_compose, target: Target) -> bool:
-    """Handle the artifacts command."""
+def resolve_run_context(args, crs_compose, target: Target) -> tuple[str, str] | None:
+    """Resolve (sanitizer, run_id) from args, returning None on failure.
+
+    Shared by the artifacts and archive commands. Handles sanitizer resolution,
+    run_id normalization, and interactive run selection.
+    """
     harness = target.target_harness
     if args.sanitizer is not None:
         sanitizer = args.sanitizer
     else:
         sanitizer = crs_compose.resolve_effective_sanitizer(target)
         if sanitizer is None:
-            return False
+            return None
     work_dir = crs_compose.work_dir
 
-    # run_id for SUBMIT/FETCH/SHARED dirs.
     # If --run-id is provided and not found on disk yet, still accept it and
     # normalize to deterministic run-scoped paths (pre-run resolution).
     if args.run_id:
@@ -89,11 +92,31 @@ def handle_artifacts(args, crs_compose, target: Target) -> bool:
                 run_id = normalize_run_id(args.run_id)
             except ValueError:
                 print(f"Invalid run id '{args.run_id}'.", file=sys.stderr)
-                return False
+                return None
+    elif getattr(args, "latest", False):
+        all_run_ids = collect_run_ids_for_target(
+            crs_compose, target, harness, sanitizer
+        )
+        if not all_run_ids:
+            print("No runs found for this target.", file=sys.stderr)
+            return None
+        run_id = all_run_ids[0]
     else:
         run_id = select_run_id_interactively(crs_compose, target, harness, sanitizer)
         if run_id is None:
-            return False
+            return None
+
+    return sanitizer, run_id
+
+
+def handle_artifacts(args, crs_compose, target: Target) -> bool:
+    """Handle the artifacts command."""
+    ctx = resolve_run_context(args, crs_compose, target)
+    if ctx is None:
+        return False
+    sanitizer, run_id = ctx
+    harness = target.target_harness
+    work_dir = crs_compose.work_dir
 
     # build_id for BUILD_OUT_DIR - use provided, read from run, or find latest
     if args.build_id:

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -9,6 +9,7 @@ from ..crs_compose import CRSCompose
 from ..config.crs_compose import CRSComposeConfig
 from ..target import Target
 from .artifacts import handle_artifacts
+from .archive import handle_archive
 from .clean import add_clean_command, handle_clean
 from .setup import add_setup_command, handle_setup
 
@@ -263,6 +264,60 @@ def add_artifacts_command(subparsers):
             "selection is used. If provided but not found yet, paths are still "
             "computed deterministically for pre-run resolution."
         ),
+    )
+    artifacts.add_argument(
+        "--latest",
+        action="store_true",
+        default=False,
+        help="Automatically select the most recent run instead of prompting interactively.",
+    )
+
+
+def add_archive_command(subparsers):
+    archive = subparsers.add_parser(
+        "archive",
+        help="Package submitted artifacts from a run into a tarball",
+    )
+    add_common_arguments(archive)
+    add_target_resolution_arguments(archive)
+    archive.add_argument(
+        "--target-harness",
+        type=str,
+        required=False,
+        default=None,
+        help="Target harness name",
+    )
+    archive.add_argument(
+        "--sanitizer",
+        type=str,
+        default=None,
+        help="Sanitizer used (default: resolved from compose/project.yaml, else 'address').",
+    )
+    archive.add_argument(
+        "--run-id",
+        type=str,
+        required=False,
+        default=None,
+        help="Run identifier to archive artifacts for. If omitted, interactive selection is used.",
+    )
+    archive.add_argument(
+        "--latest",
+        action="store_true",
+        default=False,
+        help="Automatically select the most recent run instead of prompting interactively.",
+    )
+    archive.add_argument(
+        "--out",
+        type=str,
+        required=True,
+        help="Output path for the tarball (e.g. results.tar.gz).",
+    )
+    archive.add_argument(
+        "--all",
+        dest="include_all",
+        action="store_true",
+        default=False,
+        help="Include all artifacts (exchange dir, logs, shared dirs) in addition to submitted artifacts.",
     )
 
 
@@ -537,6 +592,7 @@ def cli() -> bool | int:
     add_build_target_command(subparsers)
     add_run_command(subparsers)
     add_artifacts_command(subparsers)
+    add_archive_command(subparsers)
     add_check_command(subparsers)
     add_gen_compose_command(subparsers)
     add_clean_command(subparsers, add_common_arguments, add_target_arguments)
@@ -544,7 +600,11 @@ def cli() -> bool | int:
 
     argv = sys.argv[1:]
     _warn_deprecated_cli_aliases(argv)
-    args = parser.parse_args(argv)
+    args, unknown_args = parser.parse_known_args(argv)
+    # Only the artifacts command is designed to be called with extra args
+    # (e.g. forwarding all run args). Other commands treat unknowns as errors.
+    if unknown_args and args.command not in ("artifacts", "archive"):
+        parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
 
     # Handle setup command early - it doesn't need compose file
     if args.command == "setup":
@@ -572,7 +632,7 @@ def cli() -> bool | int:
         return handle_clean(args)
 
     # Skip CRS repo init for commands that don't need it
-    skip_crs_init = args.command == "artifacts"
+    skip_crs_init = args.command in ("artifacts", "archive")
     crs_compose = CRSCompose.from_yaml_file(
         args.compose_file, args.work_dir, skip_crs_init=skip_crs_init
     )
@@ -633,6 +693,9 @@ def cli() -> bool | int:
     elif args.command == "artifacts":
         target = init_target_from_args(args)
         return handle_artifacts(args, crs_compose, target)
+    elif args.command == "archive":
+        target = init_target_from_args(args)
+        return handle_archive(args, crs_compose, target)
     elif args.command == "check":
         pass
     return True

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -601,8 +601,9 @@ def cli() -> bool | int:
     argv = sys.argv[1:]
     _warn_deprecated_cli_aliases(argv)
     args, unknown_args = parser.parse_known_args(argv)
-    # Only the artifacts command is designed to be called with extra args
-    # (e.g. forwarding all run args). Other commands treat unknowns as errors.
+    # The artifacts and archive commands are designed to be called with
+    # extra args (e.g. forwarding all run args). Other commands treat
+    # unknowns as errors.
     if unknown_args and args.command not in ("artifacts", "archive"):
         parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
 

--- a/oss_crs/src/cli/crs_compose.py
+++ b/oss_crs/src/cli/crs_compose.py
@@ -283,7 +283,7 @@ def add_archive_command(subparsers):
     archive.add_argument(
         "--target-harness",
         type=str,
-        required=False,
+        required=True,
         default=None,
         help="Target harness name",
     )

--- a/oss_crs/src/ui.py
+++ b/oss_crs/src/ui.py
@@ -95,6 +95,7 @@ class MultiTaskProgress:
         self._current_task: Optional[str] = None  # Current task ID (full path)
         self._head = []
         self._tail = []
+        self._deferred_prints: list = []
         # Subtask hierarchy: parent_id -> list of child task IDs
         self._subtasks: dict[Optional[str], list[str]] = {None: list(self.task_names)}
         self._task_funcs: dict[str, Callable[["MultiTaskProgress"], TaskResult]] = {
@@ -597,6 +598,9 @@ class MultiTaskProgress:
             self._live.__exit__(*args)
             self._live = None
         self._entered = False
+        for item in self._deferred_prints:
+            self.console.print(item, soft_wrap=True)
+        self._deferred_prints.clear()
 
     def run_command_with_streaming_output(
         self,
@@ -750,14 +754,19 @@ class MultiTaskProgress:
 
     def show_run_result(self, crs_results: list[dict]) -> None:
         """
-        Display a summary of CRS run results in a dedicated panel.
+        Display a summary of CRS run results.
+
+        Deferred to print after the Live context exits so that long directory
+        paths are never truncated by panel border wrapping.
 
         Args:
             crs_results: List of dicts with keys:
                 - name: CRS name
                 - submit_dir: Path to the CRS submit directory
         """
-        lines = Text()
+        output = Text()
+        output.append("\nCRS Run Results\n", style="bold green")
+        output.append("─" * 40 + "\n", style="green")
         for i, entry in enumerate(crs_results):
             submit_dir = entry["submit_dir"]
             pov_dir = submit_dir / "povs"
@@ -768,33 +777,24 @@ class MultiTaskProgress:
             seed_count = _count_files(seed_dir)
             patch_count = _count_files(patch_dir)
 
-            lines.append(f"{entry['name']}:\n", style="bold cyan")
-            lines.append("  - Patches: ", style="bold")
-            lines.append(f"{patch_count}\n", style="yellow")
-            lines.append("       - Directory: ", style="dim")
-            lines.append(f"{patch_dir}\n" if patch_dir.exists() else "-\n", style="dim")
-            lines.append("  - POVs: ", style="bold")
-            lines.append(f"{pov_count}\n", style="red")
-            lines.append("       - Directory: ", style="dim")
-            lines.append(f"{pov_dir}\n" if pov_dir.exists() else "-\n", style="dim")
-            lines.append("  - Seeds: ", style="bold")
-            lines.append(f"{seed_count}\n", style="green")
-            lines.append("       - Directory: ", style="dim")
-            lines.append(f"{seed_dir}\n" if seed_dir.exists() else "-\n", style="dim")
+            output.append(f"{entry['name']}:\n", style="bold cyan")
+            output.append("  Patches: ", style="bold")
+            output.append(f"{patch_count}\n", style="yellow")
+            if patch_count > 0:
+                output.append(f"    {patch_dir}\n", style="dim")
+            output.append("  POVs: ", style="bold")
+            output.append(f"{pov_count}\n", style="red")
+            if pov_count > 0:
+                output.append(f"    {pov_dir}\n", style="dim")
+            output.append("  Seeds: ", style="bold")
+            output.append(f"{seed_count}\n", style="green")
+            if seed_count > 0:
+                output.append(f"    {seed_dir}\n", style="dim")
 
             if i < len(crs_results) - 1:
-                lines.append("\n")
+                output.append("\n")
 
-        result_panel = Panel(
-            lines,
-            title="[bold]CRS Run Results[/bold]",
-            border_style="green",
-        )
-        self._tail.append(result_panel)
-        if self._headless:
-            self._print_headless(result_panel)
-        if self._live:
-            self._live.update(self._build_display())
+        self._deferred_prints.append(output)
 
     def docker_compose_build(
         self,

--- a/oss_crs/tests/unit/test_cli_archive.py
+++ b/oss_crs/tests/unit/test_cli_archive.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for the archive command and --latest flag."""
+
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from oss_crs.src.cli.archive import handle_archive
+from oss_crs.src.cli.artifacts import resolve_run_context
+
+
+# ---------------------------------------------------------------------------
+# Shared test infrastructure
+# ---------------------------------------------------------------------------
+
+
+class _FakeWorkDir:
+    def __init__(self, tmp_path: Path):
+        self._tmp = tmp_path
+
+    def resolve_run_id(self, raw: str, _sanitizer: str) -> str:
+        # Always treat the run as already existing (simulates on-disk run).
+        return raw
+
+    def get_submit_dir(
+        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+    ) -> Path:
+        p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "SUBMIT_DIR"
+        if create:
+            p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def get_exchange_dir(self, _target, run_id: str, sanitizer: str, *, create: bool = False) -> Path:
+        p = self._tmp / sanitizer / "runs" / run_id / "EXCHANGE_DIR"
+        if create:
+            p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def get_run_logs_dir(self, _target, run_id: str, sanitizer: str, *, create: bool = False) -> Path:
+        p = self._tmp / sanitizer / "runs" / run_id / "logs"
+        if create:
+            p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def get_shared_dir(
+        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+    ) -> Path:
+        p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "SHARED_DIR"
+        if create:
+            p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def get_log_dir(
+        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+    ) -> Path:
+        p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "LOG_DIR"
+        if create:
+            p.mkdir(parents=True, exist_ok=True)
+        return p
+
+
+def _make_crs(name: str, *, is_triage: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(name=name, config=SimpleNamespace(is_triage=is_triage))
+
+
+def _make_compose(tmp_path: Path, crs_list: list) -> SimpleNamespace:
+    return SimpleNamespace(
+        work_dir=_FakeWorkDir(tmp_path),
+        crs_list=crs_list,
+        resolve_effective_sanitizer=lambda _target: "address",
+    )
+
+
+def _make_target(harness: str = "fuzz_target") -> SimpleNamespace:
+    return SimpleNamespace(target_harness=harness)
+
+
+def _make_args(
+    *,
+    run_id: str | None = None,
+    latest: bool = False,
+    sanitizer: str = "address",
+    out: str = "out.tar.gz",
+    include_all: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        run_id=run_id,
+        latest=latest,
+        sanitizer=sanitizer,
+        out=out,
+        include_all=include_all,
+    )
+
+
+def _write_file(path: Path, content: str = "data") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+def _tar_members(tar_path: Path) -> set[str]:
+    with tarfile.open(tar_path, "r:gz") as tar:
+        return {m.name for m in tar.getmembers()}
+
+
+# ---------------------------------------------------------------------------
+# --latest tests (via resolve_run_context)
+# ---------------------------------------------------------------------------
+
+
+def test_latest_picks_most_recent_run(tmp_path: Path, monkeypatch) -> None:
+    run_ids = ["1700000002ab", "1700000001xy"]
+    monkeypatch.setattr(
+        "oss_crs.src.cli.artifacts.collect_run_ids_for_target",
+        lambda *_a, **_kw: run_ids,
+    )
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    args = SimpleNamespace(run_id=None, latest=True, sanitizer="address")
+    target = _make_target()
+
+    ctx = resolve_run_context(args, compose, target)
+    assert ctx is not None
+    _, run_id = ctx
+    assert run_id == "1700000002ab"
+
+
+def test_latest_returns_none_when_no_runs(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "oss_crs.src.cli.artifacts.collect_run_ids_for_target",
+        lambda *_a, **_kw: [],
+    )
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    args = SimpleNamespace(run_id=None, latest=True, sanitizer="address")
+    target = _make_target()
+
+    ctx = resolve_run_context(args, compose, target)
+    assert ctx is None
+    assert "No runs found" in capsys.readouterr().err
+
+
+def test_run_id_takes_precedence_over_latest(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "oss_crs.src.cli.artifacts.collect_run_ids_for_target",
+        lambda *_a, **_kw: ["1700000002ab"],
+    )
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    # Use a timestamped id so resolve_run_id returns it directly (no normalization)
+    explicit_id = "1700000099zz"
+    args = SimpleNamespace(run_id=explicit_id, latest=True, sanitizer="address")
+    target = _make_target()
+
+    ctx = resolve_run_context(args, compose, target)
+    assert ctx is not None
+    _, run_id = ctx
+    # --latest should be ignored; the explicit run_id wins
+    assert run_id == explicit_id
+    assert run_id != "1700000002ab"
+
+
+# ---------------------------------------------------------------------------
+# archive: basic collection (no triage)
+# ---------------------------------------------------------------------------
+
+
+def test_archive_collects_all_subdirs_from_all_crs(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    crs_a = _make_crs("crs-a")
+    compose = _make_compose(tmp_path, [crs_a])
+    work_dir = compose.work_dir
+
+    submit = work_dir.get_submit_dir("crs-a", None, run_id, "address")
+    _write_file(submit / "povs" / "crash-001")
+    _write_file(submit / "seeds" / "seed-001")
+    _write_file(submit / "patches" / "patch-001.diff")
+    _write_file(submit / "bug-candidates" / "bug-001")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "povs/crash-001" in members
+    assert "seeds/seed-001" in members
+    assert "patches/patch-001.diff" in members
+    assert "bug-candidates/bug-001" in members
+
+
+def test_archive_returns_false_when_no_artifacts(tmp_path: Path, capsys) -> None:
+    run_id = "1700000001ab"
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is False
+    assert "No artifacts found" in capsys.readouterr().err
+
+
+def test_archive_multiple_crs_no_triage(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    crs_a, crs_b = _make_crs("crs-a"), _make_crs("crs-b")
+    compose = _make_compose(tmp_path, [crs_a, crs_b])
+    work_dir = compose.work_dir
+
+    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-a")
+    _write_file(work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash-b")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "povs/crash-a" in members
+    # crash-b collides on arcname and gets a suffix
+    assert any(m.startswith("povs/crash-b") for m in members)
+
+
+# ---------------------------------------------------------------------------
+# archive: triage CRS routing
+# ---------------------------------------------------------------------------
+
+
+def test_archive_triage_povs_from_triage_not_finder(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    finder = _make_crs("crs-finder", is_triage=False)
+    triage = _make_crs("crs-triage", is_triage=True)
+    compose = _make_compose(tmp_path, [finder, triage])
+    work_dir = compose.work_dir
+
+    # Both produce POVs — only triage's should end up in the archive
+    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "povs" / "raw-pov")
+    _write_file(work_dir.get_submit_dir("crs-triage", None, run_id, "address") / "povs" / "triaged-pov")
+    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "seeds" / "seed-001")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "povs/triaged-pov" in members
+    assert "povs/raw-pov" not in members
+    assert "seeds/seed-001" in members
+
+
+def test_archive_triage_non_pov_artifacts_from_non_triage(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    finder = _make_crs("crs-finder", is_triage=False)
+    triage = _make_crs("crs-triage", is_triage=True)
+    compose = _make_compose(tmp_path, [finder, triage])
+    work_dir = compose.work_dir
+
+    _write_file(work_dir.get_submit_dir("crs-triage", None, run_id, "address") / "povs" / "triaged-pov")
+    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "patches" / "patch-001.diff")
+    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "bug-candidates" / "bug-001")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "patches/patch-001.diff" in members
+    assert "bug-candidates/bug-001" in members
+
+
+# ---------------------------------------------------------------------------
+# archive: --all flag
+# ---------------------------------------------------------------------------
+
+
+def test_archive_all_includes_exchange_and_logs(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    work_dir = compose.work_dir
+
+    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001")
+    _write_file(work_dir.get_exchange_dir(None, run_id, "address") / "extra.bin")
+    _write_file(work_dir.get_run_logs_dir(None, run_id, "address") / "compose.log")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out), include_all=True)
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "povs/crash-001" in members
+    assert "exchange/extra.bin" in members
+    assert "logs/compose.log" in members
+
+
+def test_archive_default_excludes_exchange_and_logs(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    compose = _make_compose(tmp_path, [_make_crs("crs-a")])
+    work_dir = compose.work_dir
+
+    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001")
+    _write_file(work_dir.get_exchange_dir(None, run_id, "address") / "extra.bin")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out), include_all=False)
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    assert "exchange/extra.bin" not in members
+
+
+# ---------------------------------------------------------------------------
+# archive: arcname deduplication
+# ---------------------------------------------------------------------------
+
+
+def test_archive_deduplicates_colliding_arcnames(tmp_path: Path) -> None:
+    run_id = "1700000001ab"
+    crs_a, crs_b = _make_crs("crs-a"), _make_crs("crs-b")
+    compose = _make_compose(tmp_path, [crs_a, crs_b])
+    work_dir = compose.work_dir
+
+    # Both CRSs produce a file with the same name
+    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash", "a")
+    _write_file(work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash", "b")
+
+    out = tmp_path / "results.tar.gz"
+    args = _make_args(run_id=run_id, out=str(out))
+    ok = handle_archive(args, compose, _make_target())
+
+    assert ok is True
+    members = _tar_members(out)
+    # Both files present, one with a suffix
+    assert "povs/crash" in members
+    assert "povs/crash.1" in members

--- a/oss_crs/tests/unit/test_cli_archive.py
+++ b/oss_crs/tests/unit/test_cli_archive.py
@@ -5,8 +5,6 @@ import tarfile
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 from oss_crs.src.cli.archive import handle_archive
 from oss_crs.src.cli.artifacts import resolve_run_context
 
@@ -25,27 +23,43 @@ class _FakeWorkDir:
         return raw
 
     def get_submit_dir(
-        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+        self,
+        crs_name: str,
+        _target,
+        run_id: str,
+        sanitizer: str,
+        *,
+        create: bool = False,
     ) -> Path:
         p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "SUBMIT_DIR"
         if create:
             p.mkdir(parents=True, exist_ok=True)
         return p
 
-    def get_exchange_dir(self, _target, run_id: str, sanitizer: str, *, create: bool = False) -> Path:
+    def get_exchange_dir(
+        self, _target, run_id: str, sanitizer: str, *, create: bool = False
+    ) -> Path:
         p = self._tmp / sanitizer / "runs" / run_id / "EXCHANGE_DIR"
         if create:
             p.mkdir(parents=True, exist_ok=True)
         return p
 
-    def get_run_logs_dir(self, _target, run_id: str, sanitizer: str, *, create: bool = False) -> Path:
+    def get_run_logs_dir(
+        self, _target, run_id: str, sanitizer: str, *, create: bool = False
+    ) -> Path:
         p = self._tmp / sanitizer / "runs" / run_id / "logs"
         if create:
             p.mkdir(parents=True, exist_ok=True)
         return p
 
     def get_shared_dir(
-        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+        self,
+        crs_name: str,
+        _target,
+        run_id: str,
+        sanitizer: str,
+        *,
+        create: bool = False,
     ) -> Path:
         p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "SHARED_DIR"
         if create:
@@ -53,7 +67,13 @@ class _FakeWorkDir:
         return p
 
     def get_log_dir(
-        self, crs_name: str, _target, run_id: str, sanitizer: str, *, create: bool = False
+        self,
+        crs_name: str,
+        _target,
+        run_id: str,
+        sanitizer: str,
+        *,
+        create: bool = False,
     ) -> Path:
         p = self._tmp / sanitizer / "runs" / run_id / "crs" / crs_name / "LOG_DIR"
         if create:
@@ -206,8 +226,12 @@ def test_archive_multiple_crs_no_triage(tmp_path: Path) -> None:
     compose = _make_compose(tmp_path, [crs_a, crs_b])
     work_dir = compose.work_dir
 
-    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-a")
-    _write_file(work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash-b")
+    _write_file(
+        work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-a"
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash-b"
+    )
 
     out = tmp_path / "results.tar.gz"
     args = _make_args(run_id=run_id, out=str(out))
@@ -233,9 +257,21 @@ def test_archive_triage_povs_from_triage_not_finder(tmp_path: Path) -> None:
     work_dir = compose.work_dir
 
     # Both produce POVs — only triage's should end up in the archive
-    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "povs" / "raw-pov")
-    _write_file(work_dir.get_submit_dir("crs-triage", None, run_id, "address") / "povs" / "triaged-pov")
-    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "seeds" / "seed-001")
+    _write_file(
+        work_dir.get_submit_dir("crs-finder", None, run_id, "address")
+        / "povs"
+        / "raw-pov"
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-triage", None, run_id, "address")
+        / "povs"
+        / "triaged-pov"
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-finder", None, run_id, "address")
+        / "seeds"
+        / "seed-001"
+    )
 
     out = tmp_path / "results.tar.gz"
     args = _make_args(run_id=run_id, out=str(out))
@@ -255,9 +291,21 @@ def test_archive_triage_non_pov_artifacts_from_non_triage(tmp_path: Path) -> Non
     compose = _make_compose(tmp_path, [finder, triage])
     work_dir = compose.work_dir
 
-    _write_file(work_dir.get_submit_dir("crs-triage", None, run_id, "address") / "povs" / "triaged-pov")
-    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "patches" / "patch-001.diff")
-    _write_file(work_dir.get_submit_dir("crs-finder", None, run_id, "address") / "bug-candidates" / "bug-001")
+    _write_file(
+        work_dir.get_submit_dir("crs-triage", None, run_id, "address")
+        / "povs"
+        / "triaged-pov"
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-finder", None, run_id, "address")
+        / "patches"
+        / "patch-001.diff"
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-finder", None, run_id, "address")
+        / "bug-candidates"
+        / "bug-001"
+    )
 
     out = tmp_path / "results.tar.gz"
     args = _make_args(run_id=run_id, out=str(out))
@@ -279,7 +327,9 @@ def test_archive_all_includes_exchange_and_logs(tmp_path: Path) -> None:
     compose = _make_compose(tmp_path, [_make_crs("crs-a")])
     work_dir = compose.work_dir
 
-    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001")
+    _write_file(
+        work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001"
+    )
     _write_file(work_dir.get_exchange_dir(None, run_id, "address") / "extra.bin")
     _write_file(work_dir.get_run_logs_dir(None, run_id, "address") / "compose.log")
 
@@ -299,7 +349,9 @@ def test_archive_default_excludes_exchange_and_logs(tmp_path: Path) -> None:
     compose = _make_compose(tmp_path, [_make_crs("crs-a")])
     work_dir = compose.work_dir
 
-    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001")
+    _write_file(
+        work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash-001"
+    )
     _write_file(work_dir.get_exchange_dir(None, run_id, "address") / "extra.bin")
 
     out = tmp_path / "results.tar.gz"
@@ -323,8 +375,14 @@ def test_archive_deduplicates_colliding_arcnames(tmp_path: Path) -> None:
     work_dir = compose.work_dir
 
     # Both CRSs produce a file with the same name
-    _write_file(work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash", "a")
-    _write_file(work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash", "b")
+    _write_file(
+        work_dir.get_submit_dir("crs-a", None, run_id, "address") / "povs" / "crash",
+        "a",
+    )
+    _write_file(
+        work_dir.get_submit_dir("crs-b", None, run_id, "address") / "povs" / "crash",
+        "b",
+    )
 
     out = tmp_path / "results.tar.gz"
     args = _make_args(run_id=run_id, out=str(out))


### PR DESCRIPTION
## Summary

Added `archive` command to tarball artifacts (i.e. povs, seeds, patches, bug candidates), introduced `--latest` option for `artifacts` command to make it non-interactive, fixed rendering of full artifact paths after a `run` command finishes (so user can copy full path without annoying newline break)

## User Impact

- [x] User-facing change
- [ ] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [x] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [ ] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [x] I followed Conventional Commits
- [x] I updated docs for behavior/config/CLI changes
- [ ] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
