### PR TITLE
feat(config): validate required_envs before run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ stricter subset of Keep a Changelog).
 ## [Unreleased]
 
 ### Added
+- `required_envs` in CRS configuration — declares environment variables a CRS needs and fails fast before `oss-crs run` when they are missing from the host environment and compose `additional_env`.
 - `oss-crs archive` command — packages submitted artifacts (POVs, seeds, patches, bug-candidates) from a run into a `.tar.gz`. When a triage CRS is present, POVs are sourced from its submit dir instead of individual CRS submit dirs. Use `--all` to also include exchange dir, logs, and shared dirs. Supports `--run-id`, `--latest`, and `--sanitizer` for run selection.
 - `--latest` flag for `oss-crs artifacts` and `oss-crs archive` — automatically selects the most recent run instead of prompting interactively.
 - `oss-crs gen-compose --litellm-proxy KEY_ENV PROVIDERS [BASE_URL_ENV]` — override litellm config env vars to route selected providers through a proxy. Only rewrites entries that use known default provider keys; custom keys (e.g. `VLLM_KEY`) are never touched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ stricter subset of Keep a Changelog).
 
 ### Added
 - `required_envs` in CRS configuration — declares environment variables a CRS needs and fails fast before `oss-crs run` when they are missing from the host environment and compose `additional_env`.
+- `additional_env` preflight warnings for optional env placeholders that reference unset host environment variables.
 - `oss-crs archive` command — packages submitted artifacts (POVs, seeds, patches, bug-candidates) from a run into a `.tar.gz`. When a triage CRS is present, POVs are sourced from its submit dir instead of individual CRS submit dirs. Use `--all` to also include exchange dir, logs, and shared dirs. Supports `--run-id`, `--latest`, and `--sanitizer` for run selection.
 - `--latest` flag for `oss-crs artifacts` and `oss-crs archive` — automatically selects the most recent run instead of prompting interactively.
 - `oss-crs gen-compose --litellm-proxy KEY_ENV PROVIDERS [BASE_URL_ENV]` — override litellm config env vars to route selected providers through a proxy. Only rewrites entries that use known default provider keys; custom keys (e.g. `VLLM_KEY`) are never touched.

--- a/docs/config/crs.md
+++ b/docs/config/crs.md
@@ -35,6 +35,7 @@ The root `CRSConfig` object contains the following fields:
 | `supported_target` | `SupportedTarget` | Yes | Defines what targets this CRS supports |
 | `required_llms` | `list[string]` | No | Minimum required LLM model names (duplicates are automatically removed). This is for dependency validation, not a runtime allowlist. |
 | `required_inputs` | `list[string]` | No | Input channels this CRS requires to function. Valid names: `diff`, `pov`, `seed`, `bug-candidate`. When declared, `oss-crs run` validates that the corresponding CLI flags were provided before spawning containers. |
+| `required_envs` | `list[string]` | No | Environment variable names this CRS requires. When declared, `oss-crs run` validates that each variable is present in the host environment or provided through `additional_env` before spawning containers. |
 
 ### Example
 
@@ -71,6 +72,8 @@ required_llms:
 required_inputs:
   - diff
   - bug-candidate
+required_envs:
+  - COPILOT_GITHUB_TOKEN
 ```
 
 ---

--- a/docs/config/crs.md
+++ b/docs/config/crs.md
@@ -35,7 +35,7 @@ The root `CRSConfig` object contains the following fields:
 | `supported_target` | `SupportedTarget` | Yes | Defines what targets this CRS supports |
 | `required_llms` | `list[string]` | No | Minimum required LLM model names (duplicates are automatically removed). This is for dependency validation, not a runtime allowlist. |
 | `required_inputs` | `list[string]` | No | Input channels this CRS requires to function. Valid names: `diff`, `pov`, `seed`, `bug-candidate`. When declared, `oss-crs run` validates that the corresponding CLI flags were provided before spawning containers. |
-| `required_envs` | `list[string]` | No | Environment variable names this CRS requires. When declared, `oss-crs run` validates that each variable is present in the host environment or provided through `additional_env` before spawning containers. |
+| `required_envs` | `list[string]` | No | Environment variable names this CRS requires. When declared, `oss-crs run` validates that each variable is present in the host environment or provided through `additional_env` before spawning containers. Optional `additional_env` placeholders that reference unset host variables are reported as warnings instead of failures. |
 
 ### Example
 

--- a/docs/crs-development-guide.md
+++ b/docs/crs-development-guide.md
@@ -118,6 +118,11 @@ required_llms:
 required_inputs:
   - diff
   - bug-candidate
+
+# Only needed if your CRS requires environment variables to function.
+# OSS-CRS will fail fast before spawning containers if these are missing.
+required_envs:
+  - COPILOT_GITHUB_TOKEN
 ```
 
 ### Configuration Fields
@@ -134,6 +139,7 @@ required_inputs:
 | `supported_target` | Languages, sanitizers, architectures, and modes your CRS supports |
 | `required_llms` | *(Optional)* Minimum required LLM model names your CRS needs (validation baseline) |
 | `required_inputs` | *(Optional)* Input channels the CRS requires (`diff`, `pov`, `seed`, `bug-candidate`). Validated before run. |
+| `required_envs` | *(Optional)* Environment variable names the CRS requires. Validated before run against the host environment and compose `additional_env`. |
 
 For the complete schema reference, see [config/crs.md](config/crs.md).
 
@@ -808,6 +814,7 @@ Before publishing your CRS, verify:
 - [ ] `supported_target` accurately reflects your CRS capabilities
 - [ ] `required_llms` lists all models used (if any)
 - [ ] `required_inputs` lists inputs the CRS depends on (if any)
+- [ ] `required_envs` lists environment variables the CRS depends on (if any)
 - [ ] The CRS runs successfully against at least one OSS-Fuzz project
 
 **Additional checks for bug-fixing CRSs (builder sidecar):**

--- a/oss_crs/src/config/crs.py
+++ b/oss_crs/src/config/crs.py
@@ -6,7 +6,7 @@ from typing import Optional, Set
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from ..env_schema import validate_additional_env_keys
+from ..env_schema import ENV_KEY_PATTERN, validate_additional_env_keys
 from .target import FuzzingEngine, TargetLangauge, TargetSanitizer, TargetArch
 
 # Prefix for framework-provided infrastructure modules (e.g., "oss-crs-infra:default-builder")
@@ -182,6 +182,7 @@ class CRSConfig(BaseModel):
 
     required_llms: Optional[list[str]] = Field(default=None)
     required_inputs: Optional[list[str]] = Field(default=None)
+    required_envs: Optional[list[str]] = Field(default=None)
 
     @property
     def is_bug_fixing(self) -> bool:
@@ -234,6 +235,19 @@ class CRSConfig(BaseModel):
             raise ValueError(
                 f"Unknown input names: {sorted(invalid)}. "
                 f"Valid names: {sorted(VALID_REQUIRED_INPUT_NAMES)}"
+            )
+        return list(set(v))  # Remove duplicates
+
+    @field_validator("required_envs")
+    @classmethod
+    def validate_required_envs(cls, v: Optional[list[str]]) -> Optional[list[str]]:
+        if v is None:
+            return v
+        invalid = [name for name in v if not ENV_KEY_PATTERN.match(str(name))]
+        if invalid:
+            raise ValueError(
+                f"Invalid environment variable names: {sorted(set(invalid))}. "
+                "Expected pattern: [A-Za-z_][A-Za-z0-9_]*"
             )
         return list(set(v))  # Remove duplicates
 

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -37,6 +37,23 @@ import docker.errors
 import requests.exceptions
 
 
+_ENV_INTERPOLATION_RE = re.compile(
+    r"(?<!\$)\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?+])[^}]*)?\}|([A-Za-z_][A-Za-z0-9_]*))"
+)
+
+
+def _additional_env_value_is_resolved(value: object, host_envs: set[str]) -> bool:
+    """Return whether a compose additional_env value can be resolved now."""
+    for match in _ENV_INTERPOLATION_RE.finditer(str(value)):
+        env_name = match.group(1) or match.group(3)
+        operator = match.group(2)
+        if operator in ("-", ":-"):
+            continue
+        if env_name not in host_envs:
+            return False
+    return True
+
+
 class CRSCompose:
     @classmethod
     def from_yaml_file(
@@ -914,6 +931,56 @@ class CRSCompose:
             return TaskResult(success=False, error="\n".join(errors))
         return TaskResult(success=True)
 
+    def _validate_required_envs(self) -> TaskResult:
+        """Validate that all CRS-declared required_envs are available."""
+        errors: list[str] = []
+        host_envs = set(os.environ)
+
+        for crs in self.crs_list:
+            required_envs = getattr(crs.config, "required_envs", None)
+            if not required_envs:
+                continue
+
+            additional_envs: set[str] = set()
+            resource = getattr(crs, "resource", None)
+            if resource is not None and getattr(resource, "additional_env", None):
+                additional_envs.update(
+                    key
+                    for key, value in resource.additional_env.items()
+                    if _additional_env_value_is_resolved(value, host_envs)
+                )
+            target_build_phase = getattr(crs.config, "target_build_phase", None)
+            if target_build_phase is not None:
+                for build in target_build_phase.builds:
+                    additional_envs.update(
+                        key
+                        for key, value in build.additional_env.items()
+                        if _additional_env_value_is_resolved(value, host_envs)
+                    )
+            crs_run_phase = getattr(crs.config, "crs_run_phase", None)
+            if crs_run_phase is not None:
+                for module in crs_run_phase.modules.values():
+                    additional_envs.update(
+                        key
+                        for key, value in module.additional_env.items()
+                        if _additional_env_value_is_resolved(value, host_envs)
+                    )
+
+            available = host_envs | additional_envs
+            missing = set(required_envs) - available
+            if missing:
+                env_list = ", ".join(sorted(missing))
+                errors.append(
+                    f"CRS '{crs.name}' requires environment variables "
+                    f"{env_list} but they were not provided. "
+                    f"Please set them in the host environment or provide them "
+                    "through additional_env."
+                )
+
+        if errors:
+            return TaskResult(success=False, error="\n".join(errors))
+        return TaskResult(success=True)
+
     def __validate_before_run(
         self,
         target: Target,
@@ -936,6 +1003,10 @@ class CRSCompose:
                     bug_candidate=bug_candidate,
                     bug_candidate_dir=bug_candidate_dir,
                 ),
+            ),
+            (
+                "Validate required environment variables for CRS targets",
+                lambda _: self._validate_required_envs(),
             ),
         ]
 

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -8,7 +8,12 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 from .config.crs_compose import CRSComposeConfig, CRSComposeEnv, RunEnv
-from .env_policy import OSS_FUZZ_TARGET_ENV, build_target_builder_env
+from .env_policy import (
+    OSS_FUZZ_TARGET_ENV,
+    additional_env_value_is_resolved,
+    build_target_builder_env,
+    unresolved_env_references,
+)
 from .llm import LLM
 from .crs import CRS
 from .ui import MultiTaskProgress, TaskResult, EarlyExitConfig
@@ -35,23 +40,6 @@ from .cgroup import (
 import docker
 import docker.errors
 import requests.exceptions
-
-
-_ENV_INTERPOLATION_RE = re.compile(
-    r"(?<!\$)\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?+])[^}]*)?\}|([A-Za-z_][A-Za-z0-9_]*))"
-)
-
-
-def _additional_env_value_is_resolved(value: object, host_envs: set[str]) -> bool:
-    """Return whether a compose additional_env value can be resolved now."""
-    for match in _ENV_INTERPOLATION_RE.finditer(str(value)):
-        env_name = match.group(1) or match.group(3)
-        operator = match.group(2)
-        if operator in ("-", ":-"):
-            continue
-        if env_name not in host_envs:
-            return False
-    return True
 
 
 class CRSCompose:
@@ -934,40 +922,57 @@ class CRSCompose:
     def _validate_required_envs(self) -> TaskResult:
         """Validate that all CRS-declared required_envs are available."""
         errors: list[str] = []
+        warnings: list[str] = []
         host_envs = set(os.environ)
 
         for crs in self.crs_list:
             required_envs = getattr(crs.config, "required_envs", None)
-            if not required_envs:
-                continue
+            required_env_set = set(required_envs or [])
 
             additional_envs: set[str] = set()
+
+            def inspect_additional_env(
+                env_map: dict[str, object], *, source: str
+            ) -> None:
+                for key, value in env_map.items():
+                    if additional_env_value_is_resolved(value, host_envs):
+                        additional_envs.add(key)
+                        continue
+                    if key in required_env_set:
+                        continue
+                    missing_refs = ", ".join(
+                        sorted(unresolved_env_references(value, host_envs))
+                    )
+                    warnings.append(
+                        f"CRS '{crs.name}' optional {source} additional_env "
+                        f"'{key}' references unset host environment variable(s): "
+                        f"{missing_refs}. Set them to enable this optional env, "
+                        f"or add '{key}' to required_envs if it is mandatory."
+                    )
+
             resource = getattr(crs, "resource", None)
             if resource is not None and getattr(resource, "additional_env", None):
-                additional_envs.update(
-                    key
-                    for key, value in resource.additional_env.items()
-                    if _additional_env_value_is_resolved(value, host_envs)
+                inspect_additional_env(
+                    resource.additional_env,
+                    source="CRS entry",
                 )
             target_build_phase = getattr(crs.config, "target_build_phase", None)
             if target_build_phase is not None:
                 for build in target_build_phase.builds:
-                    additional_envs.update(
-                        key
-                        for key, value in build.additional_env.items()
-                        if _additional_env_value_is_resolved(value, host_envs)
+                    inspect_additional_env(
+                        build.additional_env,
+                        source="build",
                     )
             crs_run_phase = getattr(crs.config, "crs_run_phase", None)
             if crs_run_phase is not None:
                 for module in crs_run_phase.modules.values():
-                    additional_envs.update(
-                        key
-                        for key, value in module.additional_env.items()
-                        if _additional_env_value_is_resolved(value, host_envs)
+                    inspect_additional_env(
+                        module.additional_env,
+                        source="run module",
                     )
 
             available = host_envs | additional_envs
-            missing = set(required_envs) - available
+            missing = required_env_set - available
             if missing:
                 env_list = ", ".join(sorted(missing))
                 errors.append(
@@ -976,6 +981,9 @@ class CRSCompose:
                     f"Please set them in the host environment or provide them "
                     "through additional_env."
                 )
+
+        for warning in warnings:
+            log_warning(warning)
 
         if errors:
             return TaskResult(success=False, error="\n".join(errors))

--- a/oss_crs/src/env_policy.py
+++ b/oss_crs/src/env_policy.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 from dataclasses import dataclass
+import re
 from typing import Mapping
 
 from .env_schema import (
@@ -17,11 +18,33 @@ OSS_FUZZ_TARGET_ENV = {
     "FUZZING_LANGUAGE": "language",
 }
 
+ENV_INTERPOLATION_RE = re.compile(
+    r"(?<!\$)\$(?:\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?+])[^}]*)?\}|([A-Za-z_][A-Za-z0-9_]*))"
+)
+
 
 @dataclass
 class EnvPlan:
     effective_env: dict[str, str]
     warnings: list[str]
+
+
+def unresolved_env_references(value: object, host_envs: set[str]) -> set[str]:
+    """Return host env names referenced by value that are not available now."""
+    unresolved: set[str] = set()
+    for match in ENV_INTERPOLATION_RE.finditer(str(value)):
+        env_name = match.group(1) or match.group(3)
+        operator = match.group(2)
+        if operator in ("-", ":-"):
+            continue
+        if env_name not in host_envs:
+            unresolved.add(env_name)
+    return unresolved
+
+
+def additional_env_value_is_resolved(value: object, host_envs: set[str]) -> bool:
+    """Return whether a compose additional_env value can be resolved now."""
+    return not unresolved_env_references(value, host_envs)
 
 
 def _merge_envs(*env_maps: Mapping[str, str] | None) -> dict[str, str]:

--- a/oss_crs/tests/unit/config/test_crs.py
+++ b/oss_crs/tests/unit/config/test_crs.py
@@ -111,6 +111,7 @@ class TestRequiredInputs:
                 required_inputs=["diff", "pov", "seed", "bug-candidate"]
             )
         )
+        assert config.required_inputs is not None
         assert set(config.required_inputs) == {"diff", "pov", "seed", "bug-candidate"}
 
     def test_removes_duplicates(self):
@@ -118,6 +119,7 @@ class TestRequiredInputs:
         config = CRSConfig.from_dict(
             _minimal_crs_config(required_inputs=["diff", "diff", "pov"])
         )
+        assert config.required_inputs is not None
         assert len(config.required_inputs) == 2
         assert set(config.required_inputs) == {"diff", "pov"}
 
@@ -137,6 +139,44 @@ class TestRequiredInputs:
         """A single-element list is accepted."""
         config = CRSConfig.from_dict(_minimal_crs_config(required_inputs=["pov"]))
         assert config.required_inputs == ["pov"]
+
+
+class TestRequiredEnvs:
+    """Tests for required_envs field validation."""
+
+    def test_none_by_default(self):
+        """required_envs defaults to None when not specified."""
+        config = CRSConfig.from_dict(_minimal_crs_config())
+        assert config.required_envs is None
+
+    def test_accepts_valid_env_names(self):
+        """Valid environment variable names are accepted."""
+        config = CRSConfig.from_dict(
+            _minimal_crs_config(required_envs=["OPENAI_API_KEY", "_CUSTOM_TOKEN"])
+        )
+        assert config.required_envs is not None
+        assert set(config.required_envs) == {"OPENAI_API_KEY", "_CUSTOM_TOKEN"}
+
+    def test_removes_duplicates(self):
+        """Duplicate environment variable names are removed."""
+        config = CRSConfig.from_dict(
+            _minimal_crs_config(required_envs=["API_KEY", "API_KEY", "TOKEN"])
+        )
+        assert config.required_envs is not None
+        assert len(config.required_envs) == 2
+        assert set(config.required_envs) == {"API_KEY", "TOKEN"}
+
+    def test_rejects_invalid_env_names(self):
+        """Invalid environment variable names raise a validation error."""
+        with pytest.raises(ValidationError, match="Invalid environment variable names"):
+            CRSConfig.from_dict(
+                _minimal_crs_config(required_envs=["GOOD_KEY", "BAD-KEY", "1BAD"])
+            )
+
+    def test_empty_list_accepted(self):
+        """required_envs=[] is valid and distinct from None."""
+        config = CRSConfig.from_dict(_minimal_crs_config(required_envs=[]))
+        assert config.required_envs == []
 
 
 class TestCRSTypeProperties:

--- a/oss_crs/tests/unit/test_env_policy.py
+++ b/oss_crs/tests/unit/test_env_policy.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 from oss_crs.src.env_policy import (
+    additional_env_value_is_resolved,
     build_prepare_env,
     build_run_service_env,
     build_target_builder_env,
+    unresolved_env_references,
 )
 
 
@@ -15,6 +17,18 @@ def test_prepare_env_keeps_version_pinned() -> None:
     )
     assert plan.effective_env["VERSION"] == "1.2.3"
     assert any("ENV001" in warning for warning in plan.warnings)
+
+
+def test_additional_env_value_resolution_reports_unset_references() -> None:
+    host_envs = {"SET_TOKEN"}
+
+    assert additional_env_value_is_resolved("${SET_TOKEN}", host_envs)
+    assert additional_env_value_is_resolved("${OPTIONAL_TOKEN:-fallback}", host_envs)
+    assert additional_env_value_is_resolved("$$ESCAPED_TOKEN", host_envs)
+    assert not additional_env_value_is_resolved("${MISSING_TOKEN}", host_envs)
+    assert unresolved_env_references("${MISSING_TOKEN}-${SET_TOKEN}", host_envs) == {
+        "MISSING_TOKEN"
+    }
 
 
 def test_build_target_env_compose_overrides_build_step_and_system_wins() -> None:

--- a/oss_crs/tests/unit/test_required_envs.py
+++ b/oss_crs/tests/unit/test_required_envs.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for required_envs validation in CRSCompose."""
+
+from types import SimpleNamespace
+
+from oss_crs.src.crs_compose import CRSCompose
+
+
+class _FakeCRSConfig:
+    def __init__(
+        self,
+        required_envs,
+        *,
+        build_env=None,
+        module_env=None,
+    ):
+        self.required_envs = required_envs
+        self.target_build_phase = SimpleNamespace(
+            builds=[SimpleNamespace(additional_env=build_env or {})]
+        )
+        self.crs_run_phase = SimpleNamespace(
+            modules={"main": SimpleNamespace(additional_env=module_env or {})}
+        )
+
+
+class _FakeCRS:
+    def __init__(
+        self,
+        name,
+        required_envs,
+        *,
+        resource_env=None,
+        build_env=None,
+        module_env=None,
+    ):
+        self.name = name
+        self.config = _FakeCRSConfig(
+            required_envs,
+            build_env=build_env,
+            module_env=module_env,
+        )
+        self.resource = SimpleNamespace(additional_env=resource_env or {})
+
+
+def _make_compose(crs_list):
+    """Create a minimal CRSCompose-like object with a crs_list for validation."""
+    compose = object.__new__(CRSCompose)
+    compose.crs_list = crs_list
+    return compose
+
+
+def test_no_required_envs_always_passes(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose([_FakeCRS("crs-a", None)])
+    assert compose._validate_required_envs().success is True
+
+
+def test_empty_required_envs_always_passes(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose([_FakeCRS("crs-a", [])])
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_in_host_env(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    compose = _make_compose([_FakeCRS("crs-a", ["API_KEY"])])
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_in_resource_additional_env(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "secret"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_additional_env_placeholder_resolves(monkeypatch):
+    monkeypatch.setenv("API_KEY", "secret")
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "${API_KEY}"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_fails_when_additional_env_placeholder_is_missing(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "${API_KEY}"})]
+    )
+    result = compose._validate_required_envs()
+    assert result.success is False
+    assert result.error is not None
+    assert "API_KEY" in result.error
+
+
+def test_required_env_passes_when_additional_env_placeholder_has_default(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "${API_KEY:-test}"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_additional_env_escapes_dollar(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "$$API_KEY"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_in_build_additional_env(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], build_env={"API_KEY": "secret"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_passes_when_in_module_additional_env(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose(
+        [_FakeCRS("crs-a", ["API_KEY"], module_env={"API_KEY": "secret"})]
+    )
+    assert compose._validate_required_envs().success is True
+
+
+def test_required_env_fails_when_missing(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    compose = _make_compose([_FakeCRS("crs-a", ["API_KEY"])])
+    result = compose._validate_required_envs()
+    assert result.success is False
+    assert result.error is not None
+    assert "crs-a" in result.error
+    assert "API_KEY" in result.error
+    assert "host environment" in result.error
+    assert "additional_env" in result.error
+
+
+def test_multiple_crs_reports_only_unsatisfied_crs(monkeypatch):
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("TOKEN", raising=False)
+    compose = _make_compose(
+        [
+            _FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "secret"}),
+            _FakeCRS("crs-b", ["TOKEN"]),
+        ]
+    )
+    result = compose._validate_required_envs()
+    assert result.success is False
+    assert result.error is not None
+    assert "crs-a" not in result.error
+    assert "crs-b" in result.error
+    assert "TOKEN" in result.error

--- a/oss_crs/tests/unit/test_required_envs.py
+++ b/oss_crs/tests/unit/test_required_envs.py
@@ -2,6 +2,7 @@
 """Unit tests for required_envs validation in CRSCompose."""
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from oss_crs.src.crs_compose import CRSCompose
 
@@ -88,10 +89,12 @@ def test_required_env_fails_when_additional_env_placeholder_is_missing(monkeypat
     compose = _make_compose(
         [_FakeCRS("crs-a", ["API_KEY"], resource_env={"API_KEY": "${API_KEY}"})]
     )
-    result = compose._validate_required_envs()
+    with patch("oss_crs.src.crs_compose.log_warning") as mock_warn:
+        result = compose._validate_required_envs()
     assert result.success is False
     assert result.error is not None
     assert "API_KEY" in result.error
+    mock_warn.assert_not_called()
 
 
 def test_required_env_passes_when_additional_env_placeholder_has_default(monkeypatch):
@@ -153,3 +156,49 @@ def test_multiple_crs_reports_only_unsatisfied_crs(monkeypatch):
     assert "crs-a" not in result.error
     assert "crs-b" in result.error
     assert "TOKEN" in result.error
+
+
+def test_optional_additional_env_placeholder_warns_when_missing(monkeypatch):
+    monkeypatch.delenv("AIXCC_LITELLM_HOSTNAME", raising=False)
+    compose = _make_compose(
+        [
+            _FakeCRS(
+                "crs-a",
+                ["API_KEY"],
+                resource_env={
+                    "API_KEY": "secret",
+                    "AIXCC_LITELLM_HOSTNAME": "${AIXCC_LITELLM_HOSTNAME}",
+                },
+            )
+        ]
+    )
+
+    with patch("oss_crs.src.crs_compose.log_warning") as mock_warn:
+        result = compose._validate_required_envs()
+
+    assert result.success is True
+    mock_warn.assert_called_once()
+    warning = mock_warn.call_args[0][0]
+    assert "crs-a" in warning
+    assert "AIXCC_LITELLM_HOSTNAME" in warning
+    assert "optional CRS entry additional_env" in warning
+    assert "required_envs" in warning
+
+
+def test_optional_additional_env_placeholder_default_does_not_warn(monkeypatch):
+    monkeypatch.delenv("OPTIONAL_TOKEN", raising=False)
+    compose = _make_compose(
+        [
+            _FakeCRS(
+                "crs-a",
+                [],
+                resource_env={"OPTIONAL_TOKEN": "${OPTIONAL_TOKEN:-unused}"},
+            )
+        ]
+    )
+
+    with patch("oss_crs.src.crs_compose.log_warning") as mock_warn:
+        result = compose._validate_required_envs()
+
+    assert result.success is True
+    mock_warn.assert_not_called()


### PR DESCRIPTION
## Summary
- add `required_envs` to CRSConfig with environment variable name validation
- validate CRS-required env vars during run preflight against host env and compose `additional_env`
- handle unresolved `additional_env` placeholders such as `${API_KEY}` as missing when the host env is unset
- add unit tests plus docs and changelog updates

Fixes #143.

## Testing
- `uv run verify`