### PR TITLE
fix: use user-scoped snapshot locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ stricter subset of Keep a Changelog).
   `_relative_repo_hint`).
 
 ### Fixed
+- Incremental snapshot locks now use a per-user runtime/cache directory instead
+  of a shared `/tmp/oss-crs-snapshot-locks` path, avoiding cross-user
+  permission failures from stale lock files.
 - The local run path now passes a `Path` compose-file object consistently into
   `docker_compose_up()`, so helper-sidecar teardown classification applies on
   the main local run path.

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -24,6 +24,7 @@ from .utils import (
     log_success,
     log_warning,
     log_dim,
+    user_temporary_dir,
 )
 from .workdir import WorkDir
 from .cgroup import (
@@ -35,19 +36,6 @@ from .cgroup import (
 import docker
 import docker.errors
 import requests.exceptions
-
-
-def _snapshot_lock_dir() -> Path:
-    """Return a per-user lock directory for incremental snapshot creation."""
-    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime_dir:
-        return Path(runtime_dir) / "oss-crs" / "snapshot-locks"
-
-    cache_dir = os.environ.get("XDG_CACHE_HOME")
-    if cache_dir:
-        return Path(cache_dir) / "oss-crs" / "snapshot-locks"
-
-    return Path.home() / ".cache" / "oss-crs" / "snapshot-locks"
 
 
 class CRSCompose:
@@ -215,7 +203,7 @@ class CRSCompose:
 
         # File lock keyed on the content hash — serializes concurrent snapshot
         # creation for the same content across processes.
-        lock_dir = _snapshot_lock_dir()
+        lock_dir = user_temporary_dir() / "snapshot-locks"
         lock_path = lock_dir / f"snapshot-{content_key}.lock"
 
         with file_lock(lock_path):

--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -37,6 +37,19 @@ import docker.errors
 import requests.exceptions
 
 
+def _snapshot_lock_dir() -> Path:
+    """Return a per-user lock directory for incremental snapshot creation."""
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return Path(runtime_dir) / "oss-crs" / "snapshot-locks"
+
+    cache_dir = os.environ.get("XDG_CACHE_HOME")
+    if cache_dir:
+        return Path(cache_dir) / "oss-crs" / "snapshot-locks"
+
+    return Path.home() / ".cache" / "oss-crs" / "snapshot-locks"
+
+
 class CRSCompose:
     @classmethod
     def from_yaml_file(
@@ -202,7 +215,7 @@ class CRSCompose:
 
         # File lock keyed on the content hash — serializes concurrent snapshot
         # creation for the same content across processes.
-        lock_dir = Path("/tmp/oss-crs-snapshot-locks")
+        lock_dir = _snapshot_lock_dir()
         lock_path = lock_dir / f"snapshot-{content_key}.lock"
 
         with file_lock(lock_path):

--- a/oss_crs/src/utils.py
+++ b/oss_crs/src/utils.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MIT
 import hashlib
-import shutil
-import subprocess
+import os
 import random
-import string
-import time
 import re
+import shutil
+import string
+import subprocess
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -84,6 +85,19 @@ def generate_run_id() -> str:
     ts = int(time.time())
     suffix = "".join(random.choice(RAND_CHARS) for _ in range(2))
     return f"{ts}{suffix}"
+
+
+def user_temporary_dir() -> Path:
+    """Return a per-user directory for reusable OSS-CRS temporary state."""
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir and (runtime_path := Path(runtime_dir)).is_dir():
+        return runtime_path / "oss-crs"
+
+    cache_dir = os.environ.get("XDG_CACHE_HOME")
+    if cache_dir and (cache_path := Path(cache_dir)).is_dir():
+        return cache_path / "oss-crs"
+
+    return Path.home() / ".cache" / "oss-crs"
 
 
 def normalize_run_id(run_id: str) -> str:

--- a/oss_crs/tests/unit/test_incremental_snapshots.py
+++ b/oss_crs/tests/unit/test_incremental_snapshots.py
@@ -126,29 +126,10 @@ def _noop_lock(path):
 class TestCreateIncrementalSnapshots:
     """Tests for CRSCompose._create_incremental_snapshots()."""
 
-    def test_snapshot_lock_dir_uses_xdg_runtime_dir(self, tmp_path, monkeypatch):
-        """Snapshot locks should live under the user's runtime dir when available."""
-        from oss_crs.src.crs_compose import _snapshot_lock_dir
-
-        runtime_dir = tmp_path / "runtime"
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
-        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-
-        assert _snapshot_lock_dir() == runtime_dir / "oss-crs" / "snapshot-locks"
-
-    def test_snapshot_lock_dir_uses_xdg_cache_dir(self, tmp_path, monkeypatch):
-        """Fallback to XDG_CACHE_HOME when XDG_RUNTIME_DIR is unavailable."""
-        from oss_crs.src.crs_compose import _snapshot_lock_dir
-
-        cache_dir = tmp_path / "cache"
-        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        monkeypatch.setenv("XDG_CACHE_HOME", str(cache_dir))
-
-        assert _snapshot_lock_dir() == cache_dir / "oss-crs" / "snapshot-locks"
-
     def test_snapshot_one_uses_user_scoped_lock_dir(self, tmp_path, monkeypatch):
         """_snapshot_one should not use the legacy shared /tmp lock directory."""
         runtime_dir = tmp_path / "runtime"
+        runtime_dir.mkdir()
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
         obj = _make_crs_compose([])
 

--- a/oss_crs/tests/unit/test_incremental_snapshots.py
+++ b/oss_crs/tests/unit/test_incremental_snapshots.py
@@ -126,6 +126,59 @@ def _noop_lock(path):
 class TestCreateIncrementalSnapshots:
     """Tests for CRSCompose._create_incremental_snapshots()."""
 
+    def test_snapshot_lock_dir_uses_xdg_runtime_dir(self, tmp_path, monkeypatch):
+        """Snapshot locks should live under the user's runtime dir when available."""
+        from oss_crs.src.crs_compose import _snapshot_lock_dir
+
+        runtime_dir = tmp_path / "runtime"
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+        assert _snapshot_lock_dir() == runtime_dir / "oss-crs" / "snapshot-locks"
+
+    def test_snapshot_lock_dir_uses_xdg_cache_dir(self, tmp_path, monkeypatch):
+        """Fallback to XDG_CACHE_HOME when XDG_RUNTIME_DIR is unavailable."""
+        from oss_crs.src.crs_compose import _snapshot_lock_dir
+
+        cache_dir = tmp_path / "cache"
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(cache_dir))
+
+        assert _snapshot_lock_dir() == cache_dir / "oss-crs" / "snapshot-locks"
+
+    def test_snapshot_one_uses_user_scoped_lock_dir(self, tmp_path, monkeypatch):
+        """_snapshot_one should not use the legacy shared /tmp lock directory."""
+        runtime_dir = tmp_path / "runtime"
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+        obj = _make_crs_compose([])
+
+        client, container = _make_mock_docker_client(exit_code=0)
+        captured_locks = []
+
+        @contextmanager
+        def capture_lock(path):
+            captured_locks.append(path)
+            yield
+
+        with patch(f"{_PATCH_PREFIX}.file_lock", side_effect=capture_lock):
+            assert (
+                obj._snapshot_one(
+                    client,
+                    base_image="target:latest",
+                    tag="snapshot-tag",
+                    build_id="build-id",
+                    committed_tags=[],
+                    content_key="abc123",
+                )
+                is True
+            )
+
+        assert captured_locks == [
+            runtime_dir / "oss-crs" / "snapshot-locks" / "snapshot-abc123.lock"
+        ]
+        assert "/tmp/oss-crs-snapshot-locks" not in str(captured_locks[0])
+        container.commit.assert_called_once()
+
     def test_snapshots_created_for_all_builders(self):
         """When two builders exist, container.commit called for each builder and project image."""
         build_id = "abc123"

--- a/oss_crs/tests/unit/test_utils.py
+++ b/oss_crs/tests/unit/test_utils.py
@@ -3,7 +3,38 @@
 
 import pytest
 import re
-from oss_crs.src.utils import normalize_run_id
+from pathlib import Path
+
+from oss_crs.src.utils import normalize_run_id, user_temporary_dir
+
+
+class TestUserTemporaryDir:
+    """Tests for the reusable per-user temporary directory helper."""
+
+    def test_uses_existing_xdg_runtime_dir(self, tmp_path, monkeypatch):
+        runtime_dir = tmp_path / "runtime"
+        runtime_dir.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime_dir))
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+        assert user_temporary_dir() == runtime_dir / "oss-crs"
+
+    def test_uses_existing_xdg_cache_dir_when_runtime_missing(
+        self, tmp_path, monkeypatch
+    ):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.setenv("XDG_CACHE_HOME", str(cache_dir))
+
+        assert user_temporary_dir() == cache_dir / "oss-crs"
+
+    def test_ignores_missing_xdg_dirs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "missing-runtime"))
+        monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "missing-cache"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        assert user_temporary_dir() == tmp_path / "home" / ".cache" / "oss-crs"
 
 
 class TestNormalizeRunId:


### PR DESCRIPTION
## Summary
- move incremental snapshot lock files from the shared `/tmp/oss-crs-snapshot-locks` path to a per-user runtime/cache directory
- prefer `XDG_RUNTIME_DIR`, fall back to `XDG_CACHE_HOME`, then `~/.cache/oss-crs/snapshot-locks`
- add tests covering lock directory selection and `_snapshot_one` lock path usage

Fixes #132.

## Testing
- `uv run verify`