### PR TITLE
fix: validate sidecar path identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ stricter subset of Keep a Changelog).
   `_relative_repo_hint`).
 
 ### Fixed
+- Builder and runner sidecar APIs now reject path-like CRS, harness, and
+  rebuild identifiers before using them to resolve artifact paths.
 - The local run path now passes a `Path` compose-file object consistently into
   `docker_compose_up()`, so helper-sidecar teardown classification applies on
   the main local run path.

--- a/oss-crs-infra/builder-sidecar/server.py
+++ b/oss-crs-infra/builder-sidecar/server.py
@@ -22,12 +22,13 @@ Environment variables:
     MAX_PARALLEL_JOBS       - Thread pool size (default: "4")
 """
 
-from fastapi import FastAPI, UploadFile, File, Form
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import copy
 import hashlib
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -46,6 +47,8 @@ app = FastAPI(
     title="Builder Sidecar",
     description="Host-side ephemeral container build orchestrator",
 )
+
+_SAFE_PATH_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
 
 
 class BuildResult(BaseModel):
@@ -75,6 +78,12 @@ def _make_job_id(patch_content: bytes, builder_name: str = "") -> str:
     hasher.update(f"{project}:{sanitizer}:{builder_name}:".encode())
     hasher.update(patch_content)
     return hasher.hexdigest()[:12]
+
+
+def _validate_path_component(value: str, field_name: str) -> None:
+    """Reject path separators and traversal components from API path fields."""
+    if not _SAFE_PATH_COMPONENT_RE.fullmatch(value) or value == "." or value == "..":
+        raise HTTPException(status_code=400, detail=f"Invalid {field_name}")
 
 
 def _cached_response_for_rebuild_id(
@@ -124,6 +133,7 @@ async def submit_build(
     mem_limit: str = Form(""),
 ):
     """Submit a rebuild job. rebuild_id auto-increments if not provided."""
+    _validate_path_component(crs_name, "crs_name")
     patch_content = await patch.read()
     job_id = _make_job_id(patch_content, builder_name)
 
@@ -180,6 +190,7 @@ async def run_test(
     mem_limit: str = Form(""),
 ):
     """Submit a test job. Uses PROJECT_BASE_IMAGE."""
+    _validate_path_component(crs_name, "crs_name")
     patch_content = await patch.read()
     job_id = "test:" + _make_job_id(patch_content)
 

--- a/oss-crs-infra/runner-sidecar/server.py
+++ b/oss-crs-infra/runner-sidecar/server.py
@@ -15,10 +15,11 @@ Environment variables:
 """
 
 import os
+import re
 import subprocess
 import tempfile
 
-from fastapi import FastAPI, Form, UploadFile, File
+from fastapi import FastAPI, Form, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import uvicorn
@@ -29,11 +30,24 @@ app = FastAPI(
     description="POV reproduction service using OSS-Fuzz reproduce",
 )
 
+_SAFE_PATH_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+
 
 class POVResult(BaseModel):
     exit_code: int
     stdout: str = ""
     stderr: str
+
+
+def _validate_path_component(value: str, field_name: str) -> None:
+    """Reject path separators and traversal components from API path fields."""
+    if not _SAFE_PATH_COMPONENT_RE.fullmatch(value) or value == "." or value == "..":
+        raise HTTPException(status_code=400, detail=f"Invalid {field_name}")
+
+
+def _validate_rebuild_id(value: str | None) -> None:
+    if value is not None and not re.fullmatch(r"[0-9]+", value):
+        raise HTTPException(status_code=400, detail="Invalid rebuild_id")
 
 
 @app.get("/health")
@@ -65,6 +79,9 @@ async def run_pov(
         JSON with exit_code (0=no crash, non-zero=crash) and stderr from reproduce.
     """
     pov_timeout = int(os.environ.get("POV_TIMEOUT", "30"))
+    _validate_path_component(harness_name, "harness_name")
+    _validate_path_component(crs_name, "crs_name")
+    _validate_rebuild_id(rebuild_id)
 
     if rebuild_id is not None:
         # Rebuild artifacts: /out/{crs_name}/{rebuild_id}/build/{harness_name}

--- a/oss_crs/tests/unit/test_builder_sidecar.py
+++ b/oss_crs/tests/unit/test_builder_sidecar.py
@@ -452,6 +452,22 @@ class TestBuildEndpoint:
         assert isinstance(body["builds"], list)
         assert len(body["builds"]) >= 1
 
+    @pytest.mark.parametrize("bad_crs_name", ["../other-crs", "other/crs", ".", ".."])
+    def test_rejects_path_traversal_crs_name(self, bad_crs_name):
+        """Path-like CRS names are rejected before a build job is queued."""
+        import server
+
+        client = _make_test_client()
+        files, data = self._patch_bytes()
+        data["crs_name"] = bad_crs_name
+
+        with patch.object(server._executor, "submit") as mock_submit:
+            response = client.post("/build", files=files, data=data)
+
+        assert response.status_code == 400
+        assert "crs_name" in response.json()["detail"]
+        mock_submit.assert_not_called()
+
 
 # ===========================================================================
 # TestBuildCacheRebuildId
@@ -938,6 +954,22 @@ class TestTestEndpoint:
             data=data,
         )
         assert resp1.json()["id"] == resp2.json()["id"]
+
+    @pytest.mark.parametrize("bad_crs_name", ["../other-crs", "other/crs", ".", ".."])
+    def test_rejects_path_traversal_crs_name(self, bad_crs_name):
+        """Path-like CRS names are rejected before a test job is queued."""
+        import server
+
+        client = _make_test_client()
+        files, data = self._patch_bytes()
+        data["crs_name"] = bad_crs_name
+
+        with patch.object(server._executor, "submit") as mock_submit:
+            response = client.post("/test", files=files, data=data)
+
+        assert response.status_code == 400
+        assert "crs_name" in response.json()["detail"]
+        mock_submit.assert_not_called()
 
 
 # ===========================================================================

--- a/oss_crs/tests/unit/test_runner_sidecar.py
+++ b/oss_crs/tests/unit/test_runner_sidecar.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 import subprocess
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # Module loading: load runner-sidecar server.py under alias "runner_server"
@@ -142,6 +144,32 @@ class TestRunPOVEndpoint:
         )
         assert response.status_code == 404
         assert "error" in response.json()
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("crs_name", "../other-crs"),
+            ("crs_name", "other/crs"),
+            ("harness_name", "../secret"),
+            ("harness_name", "nested/harness"),
+            ("rebuild_id", "../1"),
+            ("rebuild_id", "abc/1"),
+        ],
+    )
+    @patch("runner_server.subprocess.run")
+    @patch("runner_server.os.path.exists")
+    def test_rejects_path_traversal_inputs(self, mock_exists, mock_run, field, value):
+        """Path-like form values are rejected before filesystem or subprocess use."""
+        client = _make_test_client()
+        upload = _pov_upload()
+        upload["data"][field] = value
+
+        response = client.post("/run-pov", **upload)
+
+        assert response.status_code == 400
+        assert field in response.json()["detail"]
+        mock_exists.assert_not_called()
+        mock_run.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- reject path-like `crs_name`, `harness_name`, and `rebuild_id` values at the sidecar API boundary
- return `400` before resolving artifact paths, checking harness files, launching subprocesses, or queueing build/test jobs
- add regression coverage for builder and runner sidecar traversal-style inputs

## Testing
- `uv run pytest oss_crs/tests/unit/test_runner_sidecar.py oss_crs/tests/unit/test_builder_sidecar.py`
- `uv run verify`