### PR TITLE
fix(config): validate CRS entry names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,4 +85,5 @@ stricter subset of Keep a Changelog).
   the main local run path.
 
 ### Security
-- N/A
+- CRS entry names are now validated at config load time before being used in
+  paths, Docker tags, service aliases, and artifact directories.

--- a/docs/config/crs-compose.md
+++ b/docs/config/crs-compose.md
@@ -306,8 +306,9 @@ The configuration is validated using Pydantic with the following rules:
    - If omitted, OSS-CRS forwards `max_budget: null` to LiteLLM during key generation (no explicit OSS-CRS budget cap).
 
 5. **CRS Entry Name Validation:**
-   - CRS entry names (keys) must be lowercase only
-   - Invalid examples: `"My-CRS"`, `"ATLANTIS"`, `"myLocalCRS"`
-   - Valid examples: `"my-crs"`, `"atlantis"`, `"my-local-crs"`
+   - CRS entry names (keys) must start with a letter or digit and contain only letters, digits, hyphens, and underscores
+   - CRS entry names may be up to 128 characters long
+   - Invalid examples: `"../evil"`, `"."`, `"my/crs"`, `"my crs"`
+   - Valid examples: `"my-crs"`, `"ATLANTIS"`, `"myLocalCRS"`
 
 ---

--- a/docs/crs-development-guide.md
+++ b/docs/crs-development-guide.md
@@ -400,6 +400,10 @@ my-crs:
 #   litellm_config: /path/to/litellm-config.yaml  # Backward-compatible legacy key; will be deprecated after gen-compose is fully implemented.
 ```
 
+The CRS entry name, such as `my-crs` above, must start with a letter or digit
+and contain only letters, digits, hyphens, and underscores. Entry names may be
+up to 128 characters long.
+
 ### Run the Three Phases
 
 ```bash

--- a/oss_crs/src/config/crs_compose.py
+++ b/oss_crs/src/config/crs_compose.py
@@ -11,7 +11,7 @@ import yaml
 from ..cpuset import parse_cpuset, map_cpuset, create_cpu_mapping
 from ..env_schema import validate_additional_env_keys
 
-CRS_ENTRY_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+CRS_ENTRY_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 
 
 class CRSSource(BaseModel):
@@ -203,8 +203,8 @@ class CRSComposeConfig(BaseModel):
         invalid_keys = [key for key in v if not CRS_ENTRY_NAME_RE.fullmatch(key)]
         if invalid_keys:
             raise ValueError(
-                "CRS entry names must start with a lowercase letter or digit and "
-                "contain only lowercase letters, digits, hyphens, and underscores "
+                "CRS entry names must start with a letter or digit and "
+                "contain only letters, digits, hyphens, and underscores "
                 f"(max 128 characters). Invalid names: {', '.join(invalid_keys)}"
             )
         return v

--- a/oss_crs/src/config/crs_compose.py
+++ b/oss_crs/src/config/crs_compose.py
@@ -11,6 +11,8 @@ import yaml
 from ..cpuset import parse_cpuset, map_cpuset, create_cpu_mapping
 from ..env_schema import validate_additional_env_keys
 
+CRS_ENTRY_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+
 
 class CRSSource(BaseModel):
     """Source configuration for a CRS entry."""
@@ -198,11 +200,12 @@ class CRSComposeConfig(BaseModel):
     @field_validator("crs_entries")
     @classmethod
     def validate_crs_entries_keys(cls, v: dict[str, CRSEntry]) -> dict[str, CRSEntry]:
-        uppercase_keys = [key for key in v.keys() if key != key.lower()]
-        if uppercase_keys:
+        invalid_keys = [key for key in v if not CRS_ENTRY_NAME_RE.fullmatch(key)]
+        if invalid_keys:
             raise ValueError(
-                f"CRS entry names must be lowercase. "
-                f"Invalid names: {', '.join(uppercase_keys)}"
+                "CRS entry names must start with a lowercase letter or digit and "
+                "contain only lowercase letters, digits, hyphens, and underscores "
+                f"(max 128 characters). Invalid names: {', '.join(invalid_keys)}"
             )
         return v
 

--- a/oss_crs/tests/unit/config/test_crs_compose.py
+++ b/oss_crs/tests/unit/config/test_crs_compose.py
@@ -177,9 +177,12 @@ class TestCRSComposeConfigEntryNames:
         "crs_name",
         [
             "crs-libfuzzer",
+            "CRS-Name",
+            "myLocalCRS",
             "42-directed",
             "atlantis-multilang-given_fuzzer",
             "a",
+            "A",
             "a" * 128,
         ],
     )
@@ -191,7 +194,6 @@ class TestCRSComposeConfigEntryNames:
     @pytest.mark.parametrize(
         "crs_name",
         [
-            "CRS-Name",
             "../evil",
             "..",
             ".",

--- a/oss_crs/tests/unit/config/test_crs_compose.py
+++ b/oss_crs/tests/unit/config/test_crs_compose.py
@@ -157,6 +157,59 @@ class TestLLMConfig:
             )
 
 
+class TestCRSComposeConfigEntryNames:
+    """Tests for CRS entry name validation at config load time."""
+
+    @staticmethod
+    def _compose_data(crs_name: str) -> dict:
+        return {
+            "run_env": "local",
+            "docker_registry": "local",
+            "oss_crs_infra": {"cpuset": "0-1", "memory": "8G"},
+            crs_name: {
+                "cpuset": "2-3",
+                "memory": "8G",
+                "source": {"local_path": "/tmp/dummy-crs"},
+            },
+        }
+
+    @pytest.mark.parametrize(
+        "crs_name",
+        [
+            "crs-libfuzzer",
+            "42-directed",
+            "atlantis-multilang-given_fuzzer",
+            "a",
+            "a" * 128,
+        ],
+    )
+    def test_valid_crs_entry_names_are_accepted(self, crs_name):
+        config = CRSComposeConfig.from_dict(self._compose_data(crs_name))
+
+        assert crs_name in config.crs_entries
+
+    @pytest.mark.parametrize(
+        "crs_name",
+        [
+            "CRS-Name",
+            "../evil",
+            "..",
+            ".",
+            "crs/name",
+            r"crs\name",
+            "crs.name",
+            "crs name",
+            "crs;inject",
+            "_starts-with-underscore",
+            "-starts-with-hyphen",
+            "a" * 129,
+        ],
+    )
+    def test_invalid_crs_entry_names_are_rejected(self, crs_name):
+        with pytest.raises(ValidationError, match="CRS entry names must start"):
+            CRSComposeConfig.from_dict(self._compose_data(crs_name))
+
+
 class TestRemoveKeys:
     """Tests for remove_keys - verifies recursive key removal."""
 


### PR DESCRIPTION
## Summary
- validate CRS entry names at config load time with a conservative path-safe pattern
- reject traversal/path-like names, dots, spaces, uppercase letters, punctuation, and overlong names before they flow into paths, Docker tags, service aliases, and artifact directories
- add regression tests for accepted current-style names and rejected unsafe names

## Compatibility
- checked current `registry/*.yaml` names and `example/*/compose.yaml` CRS keys against the new pattern

## Testing
- `uv run pytest oss_crs/tests/unit/config/test_crs_compose.py`
- `uv run python - <<'PY' ...` compatibility check for registry/example CRS names
- `uv run verify`