### PR TITLE
fix: make snapshot locks reusable across users

### DIFF
--- a/oss_crs/src/crs_compose.py
+++ b/oss_crs/src/crs_compose.py
@@ -205,7 +205,7 @@ class CRSCompose:
         lock_dir = Path("/tmp/oss-crs-snapshot-locks")
         lock_path = lock_dir / f"snapshot-{content_key}.lock"
 
-        with file_lock(lock_path):
+        with file_lock(lock_path, shared_permissions=True):
             # Re-check after acquiring lock — another process may have built it.
             try:
                 img = client.images.get(content_tag)

--- a/oss_crs/src/target.py
+++ b/oss_crs/src/target.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from typing import Optional
 import hashlib
+import os
 import posixpath
 import re
 import subprocess
@@ -32,6 +33,9 @@ OSS_FUZZ_SCRIPTS = {
 # Custom scripts from our templates directory.
 CUSTOM_SCRIPTS = ["oss_crs_handler.sh", "oss_crs_builder_server.py"]
 
+SHARED_LOCK_DIR_MODE = 0o1777
+SHARED_LOCK_FILE_MODE = 0o666
+
 
 def _ensure_third_party_oss_fuzz() -> bool:
     """Auto-fetch oss-fuzz third-party scripts if not present."""
@@ -50,17 +54,48 @@ def _ensure_third_party_oss_fuzz() -> bool:
 
 
 @contextmanager
-def file_lock(lock_path: Path):
+def file_lock(lock_path: Path, *, shared_permissions: bool = False):
     """
     Context manager for file-based locking to prevent race conditions.
 
     Args:
         lock_path: Path to the lock file
+        shared_permissions: Create/open the lock for cross-user reuse. This is
+            intended for machine-wide coordination points such as snapshot locks.
     """
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if shared_permissions:
+        lock_path.parent.mkdir(mode=SHARED_LOCK_DIR_MODE, parents=True, exist_ok=True)
+        try:
+            lock_path.parent.chmod(SHARED_LOCK_DIR_MODE)
+        except PermissionError:
+            pass
+    else:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+
     lock_file = None
     try:
-        lock_file = open(lock_path, "w")
+        if shared_permissions:
+            nofollow = getattr(os, "O_NOFOLLOW", 0)
+            try:
+                fd = os.open(
+                    lock_path,
+                    os.O_RDWR | os.O_CREAT | nofollow,
+                    SHARED_LOCK_FILE_MODE,
+                )
+            except PermissionError:
+                # Existing lock files may have been created by older versions
+                # with owner-only write permission. flock works on a read-only
+                # descriptor, so keep the global coordination point usable.
+                fd = os.open(lock_path, os.O_RDONLY | nofollow)
+                lock_file = os.fdopen(fd, "r")
+            else:
+                try:
+                    os.fchmod(fd, SHARED_LOCK_FILE_MODE)
+                except PermissionError:
+                    pass
+                lock_file = os.fdopen(fd, "r+")
+        else:
+            lock_file = open(lock_path, "w")
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         yield
     finally:

--- a/oss_crs/tests/unit/test_file_lock.py
+++ b/oss_crs/tests/unit/test_file_lock.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+import stat
+
+from oss_crs.src.target import (
+    SHARED_LOCK_DIR_MODE,
+    SHARED_LOCK_FILE_MODE,
+    file_lock,
+)
+
+
+def test_shared_file_lock_sets_shared_modes(tmp_path):
+    lock_path = tmp_path / "snapshot-locks" / "snapshot-abc.lock"
+
+    with file_lock(lock_path, shared_permissions=True):
+        dir_mode = lock_path.parent.stat().st_mode
+        file_mode = lock_path.stat().st_mode
+
+        assert dir_mode & 0o777 == SHARED_LOCK_DIR_MODE & 0o777
+        assert dir_mode & stat.S_ISVTX
+        assert file_mode & 0o777 == SHARED_LOCK_FILE_MODE
+
+    assert lock_path.exists()
+
+
+def test_shared_file_lock_reuses_read_only_existing_lock_file(tmp_path):
+    lock_dir = tmp_path / "snapshot-locks"
+    lock_dir.mkdir()
+    lock_path = lock_dir / "snapshot-abc.lock"
+    lock_path.touch()
+    lock_path.chmod(0o444)
+
+    with file_lock(lock_path, shared_permissions=True):
+        assert lock_path.exists()

--- a/oss_crs/tests/unit/test_incremental_snapshots.py
+++ b/oss_crs/tests/unit/test_incremental_snapshots.py
@@ -9,6 +9,7 @@ All Docker SDK calls are mocked — no real Docker daemon required.
 """
 
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -114,7 +115,7 @@ _PATCH_PREFIX = "oss_crs.src.crs_compose"
 
 
 @contextmanager
-def _noop_lock(path):
+def _noop_lock(path, **kwargs):
     yield
 
 
@@ -125,6 +126,37 @@ def _noop_lock(path):
 
 class TestCreateIncrementalSnapshots:
     """Tests for CRSCompose._create_incremental_snapshots()."""
+
+    def test_snapshot_lock_uses_shared_permissions(self):
+        """Snapshot locks must remain global while allowing cross-user reuse."""
+        build_id = "abc123"
+        content_key = "content123"
+        obj = _make_crs_compose([])
+        client, _ = _make_mock_docker_client(snapshot_exists=True)
+        calls = []
+
+        @contextmanager
+        def capture_lock(path, **kwargs):
+            calls.append((path, kwargs))
+            yield
+
+        with patch(f"{_PATCH_PREFIX}.file_lock", side_effect=capture_lock):
+            result = obj._snapshot_one(
+                client,
+                "base:latest",
+                "build-test-crs-builderA-abc123",
+                build_id,
+                [],
+                content_key,
+            )
+
+        assert result is True
+        assert calls == [
+            (
+                Path("/tmp/oss-crs-snapshot-locks/snapshot-content123.lock"),
+                {"shared_permissions": True},
+            )
+        ]
 
     def test_snapshots_created_for_all_builders(self):
         """When two builders exist, container.commit called for each builder and project image."""


### PR DESCRIPTION
## Summary
- keep incremental snapshot locks in the shared `/tmp/oss-crs-snapshot-locks` namespace while creating the directory and lock files with shared permissions
- make shared permissions opt-in on `file_lock()` so repo checkout locks keep their existing behavior
- fall back to read-only `flock` for existing owner-write-only lock files created by older versions
- add regression tests for shared lock modes and snapshot lock usage

Fixes #132.

## Testing
- `uv run pytest oss_crs/tests/unit/test_file_lock.py oss_crs/tests/unit/test_incremental_snapshots.py`
- `uv run ruff check oss_crs/src/target.py oss_crs/src/crs_compose.py oss_crs/tests/unit/test_file_lock.py oss_crs/tests/unit/test_incremental_snapshots.py`
- `uv run ruff format --check oss_crs/src/target.py oss_crs/src/crs_compose.py oss_crs/tests/unit/test_file_lock.py oss_crs/tests/unit/test_incremental_snapshots.py`
- `uv run verify`