### PR TITLE
refactor(sidecar): log sidecar calls server-side to jsonl

### DIFF
--- a/libCRS/libCRS/local.py
+++ b/libCRS/libCRS/local.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import json
 import logging
 import os
 import socket
@@ -18,34 +17,6 @@ logger = logging.getLogger(__name__)
 
 _FUZZ_PROJ_MOUNT = Path("/OSS_CRS_FUZZ_PROJ")
 _TARGET_SOURCE_MOUNT = Path("/OSS_CRS_TARGET_SOURCE")
-
-
-def _append_sidecar_metric(event: str, service: str, exit_code: int) -> None:
-    """Append one sidecar operation event to a JSONL metrics file."""
-    try:
-        log_dir = os.environ.get("OSS_CRS_LOG_DIR")
-        if not log_dir:
-            return
-
-        metrics_file = Path(
-            os.environ.get(
-                "OSS_CRS_SIDECAR_METRICS_FILE",
-                str(Path(log_dir) / "libcrs-sidecar-metrics.jsonl"),
-            )
-        )
-        metrics_file.parent.mkdir(parents=True, exist_ok=True)
-
-        payload = {
-            "ts": int(time.time()),
-            "crs": os.environ.get("OSS_CRS_NAME", "unknown"),
-            "event": event,
-            "service": service,
-            "exit_code": int(exit_code),
-        }
-        with metrics_file.open("a") as f:
-            f.write(json.dumps(payload, sort_keys=True) + "\n")
-    except Exception:
-        return
 
 
 def _get_build_out_dir() -> Path:
@@ -318,7 +289,6 @@ class LocalCRSUtils(CRSUtils):
         if result is None:
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Builder unavailable or timed out")
-            _append_sidecar_metric("apply-patch-build", builder, 1)
             return 1
 
         inner = result.get("result") or {}
@@ -341,7 +311,6 @@ class LocalCRSUtils(CRSUtils):
             (response_dir / "rebuild_id").write_text(str(rid))
             self._last_rebuild_id = rid
 
-        _append_sidecar_metric("apply-patch-build", builder, int(exit_code))
         return exit_code
 
     def run_pov(
@@ -358,7 +327,6 @@ class LocalCRSUtils(CRSUtils):
             response_dir.mkdir(parents=True, exist_ok=True)
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Runner unavailable")
-            _append_sidecar_metric("run-pov", builder, 1)
             return 1
 
         crs_name = os.environ.get("OSS_CRS_NAME", "unknown")
@@ -395,7 +363,6 @@ class LocalCRSUtils(CRSUtils):
             response_dir.mkdir(parents=True, exist_ok=True)
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text(str(e))
-            _append_sidecar_metric("run-pov", builder, 1)
             return 1
 
         response_dir.mkdir(parents=True, exist_ok=True)
@@ -408,7 +375,6 @@ class LocalCRSUtils(CRSUtils):
         if stderr:
             (response_dir / "stderr.log").write_text(stderr)
 
-        _append_sidecar_metric("run-pov", builder, int(exit_code))
         return exit_code
 
     def apply_patch_test(
@@ -435,7 +401,6 @@ class LocalCRSUtils(CRSUtils):
         if result is None:
             (response_dir / "retcode").write_text("1")
             (response_dir / "stderr.log").write_text("Builder unavailable or timed out")
-            _append_sidecar_metric("apply-patch-test", builder, 1)
             return 1
 
         inner = result.get("result") or {}
@@ -453,7 +418,6 @@ class LocalCRSUtils(CRSUtils):
 
         (response_dir / "retcode").write_text(str(exit_code))
 
-        _append_sidecar_metric("apply-patch-test", builder, int(exit_code))
         return exit_code
 
     def download_build_output(

--- a/oss-crs-infra/builder-sidecar/server.py
+++ b/oss-crs-infra/builder-sidecar/server.py
@@ -27,8 +27,10 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import copy
 import hashlib
+import json
 import os
 import re
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -68,6 +70,87 @@ job_results: dict[str, dict] = {}
 _executor = ThreadPoolExecutor(
     max_workers=int(os.environ.get("MAX_PARALLEL_JOBS", "4"))
 )
+
+
+# ---------------------------------------------------------------------------
+# API call logging — one JSONL line per API call, written per-CRS to the
+# host-mounted LOG_DIR (SIDECAR_LOG_DIR/{crs_name}/libcrs-sidecar-metrics.jsonl)
+# so CRS evaluation/monitoring can see every build/test invocation.
+# Best-effort: logging never blocks or fails an API call.
+# ---------------------------------------------------------------------------
+
+_API_LOG_DIR = Path(os.environ.get("SIDECAR_LOG_DIR", "/sidecar-logs"))
+_API_LOG_NAME = "libcrs-sidecar-metrics.jsonl"
+_SERVICE = "builder-sidecar"
+
+# Maps the internal job action to the canonical event name consumed by the
+# run-meta aggregation (oss_crs/src/crs_compose.py:_read_sidecar_counts_for_crs).
+_ACTION_TO_EVENT = {
+    "build": "apply-patch-build",
+    "test": "apply-patch-test",
+}
+
+
+def _init_api_log() -> None:
+    """Ensure the base API log directory exists (best-effort)."""
+    try:
+        _API_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+
+def _make_log_entry(
+    event: str,
+    job_id: str,
+    result: dict,
+    duration_ms: int,
+    ts_start: float,
+    crs_name: str,
+    service: str,
+) -> dict:
+    """Build a structured log entry for one sidecar API call.
+
+    ``exit_code`` defaults to the ``-1`` sentinel when the handler raised before
+    producing one, so derived ``crash``/``build_success`` flags stay correct.
+    """
+    exit_code = result.get("exit_code", -1)
+    entry: dict = {
+        "ts": ts_start,
+        "crs": crs_name,
+        "event": event,
+        "service": service,
+        "job_id": job_id,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+    }
+    # Pass through request/identity params returned by handlers.
+    for key in ("harness", "build_id", "rebuild_id"):
+        if key in result:
+            entry[key] = result[key]
+    if "error" in result:
+        entry["error"] = result["error"]
+    # Derived fields for consumer convenience. The ``> 0`` guard on crash keeps
+    # the ``-1`` exception sentinel from being classified as a crash.
+    if event == "apply-patch-build":
+        entry["build_success"] = exit_code == 0
+    elif event == "run-pov":
+        entry["crash"] = exit_code > 0 and exit_code != 124
+        entry["timeout"] = exit_code == 124
+    elif event == "apply-patch-test":
+        entry["test_passed"] = exit_code == 0
+        entry["skipped"] = bool(result.get("test_skipped"))
+    return entry
+
+
+def _log_api_call(crs_name: str, entry: dict) -> None:
+    """Append one compact JSON line to the per-CRS metrics file (best-effort)."""
+    try:
+        crs_dir = _API_LOG_DIR / crs_name
+        crs_dir.mkdir(parents=True, exist_ok=True)
+        with (crs_dir / _API_LOG_NAME).open("a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except Exception:
+        pass  # best-effort logging
 
 
 def _make_job_id(patch_content: bytes, builder_name: str = "") -> str:
@@ -311,12 +394,18 @@ def _handle_test(
 def _run_job(action: str, job_id: str, *args):
     """Execute a job in the thread pool."""
     job_results[job_id]["status"] = "running"
+    # crs_name is the second positional arg for both build and test jobs.
+    crs_name = args[1] if len(args) > 1 else "unknown"
+    ts_start = time.time()
+    t0 = time.monotonic()
+    result: dict = {}
     try:
         if action == "build":
             result = _handle_build(job_id, *args)
         elif action == "test":
             result = _handle_test(job_id, *args)
         else:
+            result = {"error": f"Unknown action: {action}"}
             job_results[job_id] = {
                 "id": job_id,
                 "status": "done",
@@ -325,15 +414,27 @@ def _run_job(action: str, job_id: str, *args):
             return
         job_results[job_id] = {"id": job_id, "status": "done", "result": result}
     except Exception as e:
+        result = {"error": str(e)}
         job_results[job_id] = {
             "id": job_id,
             "status": "done",
             "result": None,
             "error": str(e),
         }
+    finally:
+        event = _ACTION_TO_EVENT.get(action)
+        if event is not None:
+            duration_ms = int((time.monotonic() - t0) * 1000)
+            _log_api_call(
+                crs_name,
+                _make_log_entry(
+                    event, job_id, result, duration_ms, ts_start, crs_name, _SERVICE
+                ),
+            )
 
 
 if __name__ == "__main__":
     import uvicorn
 
+    _init_api_log()
     uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/oss-crs-infra/runner-sidecar/server.py
+++ b/oss-crs-infra/runner-sidecar/server.py
@@ -14,10 +14,14 @@ Environment variables:
     POV_TIMEOUT - Maximum seconds for reproduce script (default: "30")
 """
 
+import json
 import os
 import re
 import subprocess
 import tempfile
+import time
+import uuid
+from pathlib import Path
 
 from fastapi import FastAPI, Form, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
@@ -50,39 +54,94 @@ def _validate_rebuild_id(value: str | None) -> None:
         raise HTTPException(status_code=400, detail="Invalid rebuild_id")
 
 
+# ---------------------------------------------------------------------------
+# API call logging — one JSONL line per /run-pov call, written per-CRS to the
+# host-mounted LOG_DIR (SIDECAR_LOG_DIR/{crs_name}/libcrs-sidecar-metrics.jsonl)
+# so CRS evaluation/monitoring can see every POV reproduction.
+# Best-effort: logging never blocks or fails an API call.
+# ---------------------------------------------------------------------------
+
+_API_LOG_DIR = Path(os.environ.get("SIDECAR_LOG_DIR", "/sidecar-logs"))
+_API_LOG_NAME = "libcrs-sidecar-metrics.jsonl"
+_SERVICE = "runner-sidecar"
+
+
+def _init_api_log() -> None:
+    """Ensure the base API log directory exists (best-effort)."""
+    try:
+        _API_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+
+def _make_log_entry(
+    event: str,
+    job_id: str,
+    result: dict,
+    duration_ms: int,
+    ts_start: float,
+    crs_name: str,
+    service: str,
+) -> dict:
+    """Build a structured log entry for one sidecar API call.
+
+    ``exit_code`` defaults to the ``-1`` sentinel when the handler raised before
+    producing one, so derived ``crash``/``timeout`` flags stay correct.
+    """
+    exit_code = result.get("exit_code", -1)
+    entry: dict = {
+        "ts": ts_start,
+        "crs": crs_name,
+        "event": event,
+        "service": service,
+        "job_id": job_id,
+        "exit_code": exit_code,
+        "duration_ms": duration_ms,
+    }
+    for key in ("harness", "build_id", "rebuild_id"):
+        if key in result:
+            entry[key] = result[key]
+    if "error" in result:
+        entry["error"] = result["error"]
+    # Derived fields. The ``> 0`` guard keeps the ``-1`` exception sentinel from
+    # being classified as a crash; 124 is the timeout sentinel.
+    if event == "run-pov":
+        entry["crash"] = exit_code > 0 and exit_code != 124
+        entry["timeout"] = exit_code == 124
+    return entry
+
+
+def _log_api_call(crs_name: str, entry: dict) -> None:
+    """Append one compact JSON line to the per-CRS metrics file (best-effort)."""
+    try:
+        crs_dir = _API_LOG_DIR / crs_name
+        crs_dir.mkdir(parents=True, exist_ok=True)
+        with (crs_dir / _API_LOG_NAME).open("a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except Exception:
+        pass  # best-effort logging
+
+
 @app.get("/health")
 def health():
     """Liveness probe -- returns 200 with status ok."""
     return {"status": "ok"}
 
 
-@app.post("/run-pov")
-async def run_pov(
-    pov: UploadFile = File(...),
-    harness_name: str = Form(...),
-    crs_name: str = Form(...),
-    rebuild_id: str = Form(None),
-):
-    """Execute POV reproduction via OSS-Fuzz reproduce script.
+def _reproduce_pov(
+    pov_content: bytes,
+    harness_name: str,
+    crs_name: str,
+    rebuild_id: "str | None",
+    pov_timeout: int,
+) -> dict:
+    """Run the OSS-Fuzz reproduce script for one POV and return a result dict.
 
-    The POV binary is uploaded as a file (not a path) so the runner-sidecar
-    doesn't need access to the patcher's filesystem.
-
-    Args (form/file fields):
-        pov: The POV binary to reproduce.
-        harness_name: Name of the fuzzer harness binary (e.g., "my_fuzzer").
-        rebuild_id: Rebuild identifier (locates artifacts under /out/{crs}/{rebuild_id}/).
-                    When None, runs against the original unpatched base build.
-        crs_name: CRS identifier.
-
-    Returns:
-        JSON with exit_code (0=no crash, non-zero=crash) and stderr from reproduce.
+    The dict always carries ``exit_code``; a real run also carries
+    ``stdout``/``stderr``. The missing-harness case returns exit 127 plus
+    ``harness_path`` so the caller can render a 404. This is a plain synchronous
+    helper so the endpoint stays thin (validate, time, log, map to response).
     """
-    pov_timeout = int(os.environ.get("POV_TIMEOUT", "30"))
-    _validate_path_component(harness_name, "harness_name")
-    _validate_path_component(crs_name, "crs_name")
-    _validate_rebuild_id(rebuild_id)
-
     if rebuild_id is not None:
         # Rebuild artifacts: /out/{crs_name}/{rebuild_id}/build/{harness_name}
         out_dir = os.environ.get("OUT_DIR", "/out")
@@ -94,11 +153,9 @@ async def run_pov(
 
     harness_path = os.path.join(harness_dir, harness_name)
     if not os.path.exists(harness_path):
-        return JSONResponse(
-            status_code=404,
-            content={"error": f"Harness binary not found: {harness_path}"},
-        )
-    pov_content = await pov.read()
+        # Missing harness binary -> exit 127, classified as a crash to match
+        # the upstream reproduce-handler semantics.
+        return {"exit_code": 127, "harness_path": harness_path}
 
     with tempfile.NamedTemporaryFile(suffix=".pov", delete=False) as tmp:
         tmp.write(pov_content)
@@ -140,11 +197,17 @@ async def run_pov(
                 env=env,
                 cwd=out_for_env,
             )
-            return POVResult(
-                exit_code=result.returncode, stdout=result.stdout, stderr=result.stderr
-            )
+            return {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
         except subprocess.TimeoutExpired:
-            return POVResult(exit_code=124, stderr="POV execution timed out")
+            return {
+                "exit_code": 124,
+                "stdout": "",
+                "stderr": "POV execution timed out",
+            }
     finally:
         os.unlink(tmp_pov_path)
         if writable_out is not None:
@@ -153,5 +216,69 @@ async def run_pov(
             shutil.rmtree(writable_out, ignore_errors=True)
 
 
+@app.post("/run-pov")
+async def run_pov(
+    pov: UploadFile = File(...),
+    harness_name: str = Form(...),
+    crs_name: str = Form(...),
+    rebuild_id: str = Form(None),
+):
+    """Execute POV reproduction via OSS-Fuzz reproduce script.
+
+    The POV binary is uploaded as a file (not a path) so the runner-sidecar
+    doesn't need access to the patcher's filesystem.
+
+    Args (form/file fields):
+        pov: The POV binary to reproduce.
+        harness_name: Name of the fuzzer harness binary (e.g., "my_fuzzer").
+        rebuild_id: Rebuild identifier (locates artifacts under /out/{crs}/{rebuild_id}/).
+                    When None, runs against the original unpatched base build.
+        crs_name: CRS identifier.
+
+    Returns:
+        JSON with exit_code (0=no crash, non-zero=crash) and stderr from reproduce.
+    """
+    pov_timeout = int(os.environ.get("POV_TIMEOUT", "30"))
+    _validate_path_component(harness_name, "harness_name")
+    _validate_path_component(crs_name, "crs_name")
+    _validate_rebuild_id(rebuild_id)
+
+    pov_content = await pov.read()
+
+    job_id = uuid.uuid4().hex[:12]
+    ts_start = time.time()
+    t0 = time.monotonic()
+    result: dict = {"harness": harness_name}
+    if rebuild_id is not None:
+        result["rebuild_id"] = rebuild_id
+    try:
+        result.update(
+            _reproduce_pov(pov_content, harness_name, crs_name, rebuild_id, pov_timeout)
+        )
+    except Exception as e:
+        result["error"] = str(e)
+        raise
+    finally:
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        _log_api_call(
+            crs_name,
+            _make_log_entry(
+                "run-pov", job_id, result, duration_ms, ts_start, crs_name, _SERVICE
+            ),
+        )
+
+    if "harness_path" in result:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"Harness binary not found: {result['harness_path']}"},
+        )
+    return POVResult(
+        exit_code=result["exit_code"],
+        stdout=result.get("stdout", ""),
+        stderr=result.get("stderr", ""),
+    )
+
+
 if __name__ == "__main__":
+    _init_api_log()
     uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/oss_crs/src/config/artifacts.py
+++ b/oss_crs/src/config/artifacts.py
@@ -138,6 +138,7 @@ class CRSArtifacts(BaseModel):
     fetch: Optional[str] = None
     shared: Optional[str] = None
     log_dir: Optional[str] = None
+    sidecar_metrics: Optional[str] = None
     run_logs: Optional[str] = None
 
     @classmethod
@@ -178,6 +179,15 @@ class CRSArtifacts(BaseModel):
             artifacts.log_dir = str(
                 work_dir.get_log_dir(crs_name, target, run_id, sanitizer, create=False)
             )
+            # Per-CRS sidecar API-call log (build/test/pov), written server-side
+            # by the builder/runner sidecars under LOG_DIR. Counts are summarized
+            # in meta.crs[name].sidecar; this points at the raw JSONL trail. Only
+            # advertised when the sidecars actually produced it.
+            sidecar_metrics_path = work_dir.get_sidecar_metrics_file(
+                crs_name, target, run_id, sanitizer
+            )
+            if sidecar_metrics_path.exists():
+                artifacts.sidecar_metrics = str(sidecar_metrics_path)
             run_logs_root = work_dir.get_run_logs_dir(
                 target, run_id, sanitizer, create=False
             )

--- a/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
+++ b/oss_crs/src/templates/run-crs-compose.docker-compose.yaml.j2
@@ -245,9 +245,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - {{ rebuild_out_dir }}:/rebuild_out:rw
+{%- for crs in crs_list %}
+      - {{ work_dir.get_log_dir(crs.name, target, run_id, sanitizer) }}:/sidecar-logs/{{ crs.name }}:rw
+{%- endfor %}
     environment:
       - REBUILD_OUT_DIR=/rebuild_out
       - HOST_REBUILD_OUT_DIR={{ rebuild_out_dir }}
+      - SIDECAR_LOG_DIR=/sidecar-logs
 {%- for crs in crs_list %}
 {%- if crs.config.target_build_phase and crs.config.target_build_phase.builds %}
 {%- for build_config in crs.config.target_build_phase.builds %}
@@ -294,9 +298,11 @@ services:
       - {{ rebuild_out_dir }}:/out:rw
 {%- for crs in crs_list %}
       - {{ work_dir.get_build_output_dir(crs.name, target, build_id, sanitizer) }}:/build_out/{{ crs.name }}:ro
+      - {{ work_dir.get_log_dir(crs.name, target, run_id, sanitizer) }}:/sidecar-logs/{{ crs.name }}:rw
 {%- endfor %}
     environment:
       - BUILD_OUT_DIR=/build_out
+      - SIDECAR_LOG_DIR=/sidecar-logs
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/health')\""]
       interval: 5s

--- a/oss_crs/tests/unit/test_builder_sidecar_logging.py
+++ b/oss_crs/tests/unit/test_builder_sidecar_logging.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for sidecar server-side API-call logging.
+
+Covers the structured JSONL logging added to the builder-sidecar and
+runner-sidecar servers: ``_make_log_entry`` (build / run-pov / run-test
+classification) and ``_log_api_call`` (per-CRS JSONL file mechanics).
+
+Unlike the upstream PR, the real functions are importable here, so we test the
+actual implementation instead of a duplicated copy. Both sidecars expose a
+module named ``server``; the builder is imported via sys.path as ``server`` (to
+satisfy its local ``docker_ops`` import) and the runner is loaded via importlib
+under the collision-safe alias ``runner_server``.
+"""
+
+# ruff: noqa: E402
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_INFRA = Path(__file__).resolve().parent.parent.parent.parent / "oss-crs-infra"
+_BUILDER_DIR = _INFRA / "builder-sidecar"
+sys.path.insert(0, str(_BUILDER_DIR))
+
+import server as builder_server
+
+# Load runner-sidecar server.py under a collision-safe alias so it does not
+# clobber builder-sidecar's cached ``server`` module in the same pytest session.
+_RUNNER_SERVER_PATH = _INFRA / "runner-sidecar" / "server.py"
+_spec = importlib.util.spec_from_file_location("runner_server", _RUNNER_SERVER_PATH)
+runner_server = importlib.util.module_from_spec(_spec)
+sys.modules["runner_server"] = runner_server
+_spec.loader.exec_module(runner_server)
+
+
+def _entry(event, job_id, result, duration_ms=100, ts_start=1000.0):
+    """Call the builder server's unified _make_log_entry with test defaults."""
+    return builder_server._make_log_entry(
+        event, job_id, result, duration_ms, ts_start, "mycrs", "builder-sidecar"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_log_entry — build (apply-patch-build)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLogEntryBuild:
+    def test_success(self):
+        e = _entry("apply-patch-build", "abc123", {"exit_code": 0}, 8920, 1000.0)
+        assert e["event"] == "apply-patch-build"
+        assert e["exit_code"] == 0
+        assert e["build_success"] is True
+        assert e["ts"] == 1000.0
+        assert e["duration_ms"] == 8920
+        assert e["crs"] == "mycrs"
+        assert e["service"] == "builder-sidecar"
+
+    def test_failure(self):
+        e = _entry("apply-patch-build", "def456", {"exit_code": 1})
+        assert e["build_success"] is False
+
+    def test_handler_exception(self):
+        e = _entry("apply-patch-build", "j1", {"error": "compile crashed"})
+        assert e["exit_code"] == -1
+        assert e["build_success"] is False
+        assert e["error"] == "compile crashed"
+
+    def test_rebuild_id_passthrough(self):
+        e = _entry("apply-patch-build", "j1", {"exit_code": 0, "rebuild_id": 3})
+        assert e["rebuild_id"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_log_entry — run-pov
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLogEntryRunPov:
+    def test_crash(self):
+        result = {"exit_code": 1, "harness": "html", "rebuild_id": "2"}
+        e = _entry("run-pov", "p1", result, 2340, 1000.0)
+        assert e["crash"] is True
+        assert e["timeout"] is False
+        assert e["harness"] == "html"
+        assert e["rebuild_id"] == "2"
+
+    def test_no_crash(self):
+        e = _entry("run-pov", "p2", {"exit_code": 0, "harness": "fuzz"})
+        assert e["crash"] is False
+        assert e["timeout"] is False
+
+    def test_timeout(self):
+        e = _entry("run-pov", "p3", {"exit_code": 124, "harness": "fuzz"}, 30000, 1.0)
+        assert e["crash"] is False
+        assert e["timeout"] is True
+        assert e["exit_code"] == 124
+
+    def test_exit_77_is_crash(self):
+        """Exit 77 = libFuzzer security finding -> crash."""
+        e = _entry("run-pov", "p4", {"exit_code": 77, "harness": "fuzz"})
+        assert e["crash"] is True
+        assert e["exit_code"] == 77
+
+    def test_handler_exception_not_crash(self):
+        """Handler exception (exit_code=-1) must not be classified as crash."""
+        e = _entry("run-pov", "p5", {"error": "connection refused"})
+        assert e["crash"] is False
+        assert e["exit_code"] == -1
+        assert e["error"] == "connection refused"
+
+    def test_harness_not_found_is_crash(self):
+        """Exit 127 = harness binary missing, still classified as crash."""
+        e = _entry("run-pov", "p6", {"exit_code": 127, "harness": "missing"})
+        assert e["crash"] is True
+        assert e["harness"] == "missing"
+
+    def test_runner_server_matches(self):
+        """The runner-sidecar's own _make_log_entry classifies identically."""
+        e = runner_server._make_log_entry(
+            "run-pov",
+            "p1",
+            {"exit_code": 124, "harness": "h"},
+            5,
+            1.0,
+            "mycrs",
+            "runner-sidecar",
+        )
+        assert e["timeout"] is True
+        assert e["crash"] is False
+        assert e["service"] == "runner-sidecar"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_log_entry — run-test (apply-patch-test)
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLogEntryRunTest:
+    def test_pass(self):
+        e = _entry("apply-patch-test", "t1", {"exit_code": 0, "test_skipped": False})
+        assert e["test_passed"] is True
+        assert e["skipped"] is False
+
+    def test_fail(self):
+        e = _entry("apply-patch-test", "t2", {"exit_code": 1, "test_skipped": False})
+        assert e["test_passed"] is False
+        assert e["skipped"] is False
+
+    def test_skipped(self):
+        e = _entry("apply-patch-test", "t3", {"exit_code": 0, "test_skipped": True})
+        assert e["test_passed"] is True
+        assert e["skipped"] is True
+
+    def test_handler_exception(self):
+        e = _entry("apply-patch-test", "t4", {"error": "timeout"})
+        assert e["exit_code"] == -1
+        assert e["test_passed"] is False
+        assert e["error"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _make_log_entry — common fields
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLogEntryCommon:
+    def test_timestamp_is_start_time(self):
+        ts = 1774296986.79
+        e = _entry("apply-patch-build", "j1", {"exit_code": 0}, 1000, ts)
+        assert e["ts"] == ts
+
+    def test_required_fields_present(self):
+        for event, result in [
+            ("apply-patch-build", {"exit_code": 0}),
+            ("run-pov", {"exit_code": 1, "harness": "h"}),
+            ("apply-patch-test", {"exit_code": 0, "test_skipped": False}),
+        ]:
+            e = _entry(event, "j1", result)
+            assert all(
+                k in e
+                for k in (
+                    "ts",
+                    "crs",
+                    "event",
+                    "service",
+                    "job_id",
+                    "exit_code",
+                    "duration_ms",
+                )
+            )
+
+    def test_all_entries_json_serializable(self):
+        entries = [
+            _entry("apply-patch-build", "j1", {"exit_code": 0}),
+            _entry("run-pov", "j2", {"exit_code": 1, "harness": "h"}),
+            _entry("apply-patch-test", "j3", {"exit_code": 0, "test_skipped": False}),
+            _entry("run-pov", "j4", {"error": "fail"}),
+        ]
+        for entry in entries:
+            assert json.loads(json.dumps(entry)) == entry
+
+    def test_unknown_event(self):
+        e = _entry("unknown", "j1", {})
+        assert e["exit_code"] == -1
+        assert "crash" not in e
+        assert "build_success" not in e
+        assert "test_passed" not in e
+
+
+# ---------------------------------------------------------------------------
+# Tests: _log_api_call — per-CRS JSONL file mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestLogApiCallFile:
+    def _read_lines(self, path):
+        return [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+    def test_writes_jsonl_lines_per_crs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(builder_server, "_API_LOG_DIR", tmp_path)
+        builder_server._log_api_call("crsA", {"event": "apply-patch-build", "n": 0})
+        builder_server._log_api_call("crsA", {"event": "run-pov", "n": 1})
+
+        log_file = tmp_path / "crsA" / "libcrs-sidecar-metrics.jsonl"
+        assert log_file.exists()
+        lines = self._read_lines(log_file)
+        assert len(lines) == 2
+        assert json.loads(lines[0])["event"] == "apply-patch-build"
+        assert json.loads(lines[1])["event"] == "run-pov"
+
+    def test_routes_by_crs_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(builder_server, "_API_LOG_DIR", tmp_path)
+        builder_server._log_api_call("crsA", {"event": "run-pov"})
+        builder_server._log_api_call("crsB", {"event": "run-pov"})
+        assert (tmp_path / "crsA" / "libcrs-sidecar-metrics.jsonl").exists()
+        assert (tmp_path / "crsB" / "libcrs-sidecar-metrics.jsonl").exists()
+
+    def test_compact_json_no_spaces(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(builder_server, "_API_LOG_DIR", tmp_path)
+        builder_server._log_api_call(
+            "crsA", {"event": "apply-patch-build", "exit_code": 0}
+        )
+        line = (tmp_path / "crsA" / "libcrs-sidecar-metrics.jsonl").read_text().strip()
+        assert " " not in line  # compact separators
+
+    def test_each_line_is_valid_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(builder_server, "_API_LOG_DIR", tmp_path)
+        for i in range(5):
+            builder_server._log_api_call("crsA", {"event": "run-pov", "n": i})
+        lines = self._read_lines(tmp_path / "crsA" / "libcrs-sidecar-metrics.jsonl")
+        assert len(lines) == 5
+        for line in lines:
+            json.loads(line)  # should not raise
+
+    def test_best_effort_never_raises(self, tmp_path, monkeypatch):
+        # Point the log dir at a path that cannot be created (a file, not a dir).
+        broken = tmp_path / "afile"
+        broken.write_text("x")
+        monkeypatch.setattr(builder_server, "_API_LOG_DIR", broken)
+        # Must not raise despite the unwritable target.
+        builder_server._log_api_call("crsA", {"event": "run-pov"})

--- a/oss_crs/tests/unit/test_cli_artifacts_prerun.py
+++ b/oss_crs/tests/unit/test_cli_artifacts_prerun.py
@@ -148,6 +148,18 @@ class _FakeWorkDir:
             / target.target_harness
         )
 
+    def get_sidecar_metrics_file(
+        self,
+        crs_name: str,
+        target,
+        run_id: str,
+        sanitizer: str,
+    ):
+        return (
+            self.get_log_dir(crs_name, target, run_id, sanitizer)
+            / "libcrs-sidecar-metrics.jsonl"
+        )
+
 
 def _make_compose(
     tmp_path, resolved_run_id: str | None, resolved_sanitizer: str = "address"
@@ -269,3 +281,39 @@ def test_artifacts_includes_meta_stats_when_meta_json_exists(tmp_path, capsys) -
     assert '"patch_tests": 2' in out
     assert '"pov_runs": 8' in out
     assert '"bug_candidates": 2' in out
+
+
+def test_artifacts_advertises_per_crs_sidecar_metrics_path(tmp_path, capsys) -> None:
+    """The per-CRS artifacts block points at the sidecar API-call JSONL."""
+    compose = _make_compose(tmp_path, resolved_run_id="existing-run-id")
+    args = _make_args("existing-run-id")
+    target = _FakeTarget("fuzz_target")
+
+    # The path is only advertised once the sidecars have produced the file.
+    metrics_file = compose.work_dir.get_sidecar_metrics_file(
+        "crs-a", target, "existing-run-id", "address"
+    )
+    metrics_file.parent.mkdir(parents=True, exist_ok=True)
+    metrics_file.write_text('{"event":"run-pov"}\n')
+
+    ok = handle_artifacts(args, compose, target)
+    assert ok is True
+
+    out = json.loads(capsys.readouterr().out)
+    sidecar_path = out["crs"]["crs-a"]["sidecar_metrics"]
+    assert sidecar_path.endswith(
+        "crs/crs-a/mock-proj_deadbeef/LOG_DIR/fuzz_target/libcrs-sidecar-metrics.jsonl"
+    )
+
+
+def test_artifacts_omits_sidecar_metrics_when_file_absent(tmp_path, capsys) -> None:
+    """No sidecar_metrics key is emitted when the JSONL was never written."""
+    compose = _make_compose(tmp_path, resolved_run_id="existing-run-id")
+    args = _make_args("existing-run-id")
+    target = _FakeTarget("fuzz_target")
+
+    ok = handle_artifacts(args, compose, target)
+    assert ok is True
+
+    out = json.loads(capsys.readouterr().out)
+    assert "sidecar_metrics" not in out["crs"]["crs-a"]

--- a/oss_crs/tests/unit/test_renderer_run_compose.py
+++ b/oss_crs/tests/unit/test_renderer_run_compose.py
@@ -263,6 +263,30 @@ def test_sidecar_emits_project_base_image_env_var(monkeypatch, tmp_path: Path) -
     assert "PROJECT_BASE_IMAGE=project-image:latest" in env_list
 
 
+def test_sidecars_mount_per_crs_log_dir_for_api_logging(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Both sidecars mount each CRS's LOG_DIR and point SIDECAR_LOG_DIR at it.
+
+    This is what lets the servers write libcrs-sidecar-metrics.jsonl into the
+    same per-CRS LOG_DIR that run-meta aggregation reads.
+    """
+    _patch_renderer(monkeypatch)
+
+    crs = _make_crs(tmp_path, "crs-plain")
+    crs_compose = _make_crs_compose(tmp_path, [crs])
+    target = _make_target(tmp_path)
+
+    rendered, warnings = _render(crs_compose, target, tmp_path)
+    assert warnings == []
+
+    services = yaml.safe_load(rendered)["services"]
+    log_mount = f"{tmp_path / 'log'}:/sidecar-logs/crs-plain:rw"
+    for svc in ("oss-crs-builder-sidecar", "oss-crs-runner-sidecar"):
+        assert "SIDECAR_LOG_DIR=/sidecar-logs" in services[svc]["environment"]
+        assert log_mount in services[svc]["volumes"]
+
+
 # ---------------------------------------------------------------------------
 # ROUTE-01 / ROUTE-02: Early exit watch_dirs and artifact_subdir selection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Move jsonl sidecar logging from libCRS client to server, and add more metrics like `duration_ms`.
Also add jsonl path to `oss-crs artifacts` output.

## User Impact

- [ ] User-facing change
- [x] Internal-only change

If user-facing, describe CLI/API/config/docs impact and migration steps.

## Release Note / Changelog

- [ ] I updated `CHANGELOG.md` (`[Unreleased]`) for user-facing changes
- [x] No changelog entry needed (internal-only refactor/test/chore)

If this PR includes deprecation or breaking behavior, include:
- replacement path for users
- planned removal version/release window

## Validation

List tests/checks run and their results.

## Checklist

- [x] I followed Conventional Commits
- [ ] I updated docs for behavior/config/CLI changes
- [x] I added/updated tests for behavior changes
- [x] I considered backward compatibility and migration impact
